### PR TITLE
Update custom_error.go package from "interfaces" => "test".

### DIFF
--- a/mockery/fixtures/custom_error.go
+++ b/mockery/fixtures/custom_error.go
@@ -1,4 +1,4 @@
-package interfaces
+package test
 
 type Err struct {
 	msg  string

--- a/mockery/generator_test.go
+++ b/mockery/generator_test.go
@@ -294,11 +294,11 @@ func TestGeneratorHavingNoNamesOnArguments(t *testing.T) {
 	mock.Mock
 }
 
-func (m *KeyManager) GetKey(_a0 string, _a1 uint16) ([]byte, *interfaces.Err) {
+func (m *KeyManager) GetKey(_a0 string, _a1 uint16) ([]byte, *test.Err) {
 	ret := m.Called(_a0, _a1)
 
 	r0 := ret.Get(0).([]byte)
-	r1 := ret.Get(1).(*interfaces.Err)
+	r1 := ret.Get(1).(*test.Err)
 
 	return r0, r1
 }


### PR DESCRIPTION
This PR updates custom_error.go to be consistent in package naming with the rest of the fixtures/ directory.