### PR TITLE
Update nil check to support all nillable types.

### DIFF
--- a/mockery/generator.go
+++ b/mockery/generator.go
@@ -279,7 +279,6 @@ func (g *Generator) Generate() error {
 		default:
 			g.printf("(%s) {\n", strings.Join(returs, ", "))
 		}
-
 		if len(types) > 0 {
 			g.printf("\tret := m.Called(%s)\n\n", strings.Join(names, ", "))
 
@@ -288,7 +287,7 @@ func (g *Generator) Generate() error {
 			for idx, typ := range types {
 				if typ == "error" {
 					g.printf("\tr%d := ret.Error(%d)\n", idx, idx)
-				} else if _, ok := ftype.Results.List[idx].Type.(*ast.StarExpr); ok {
+				} else if g.isNillable(ftype.Results.List[idx].Type) {
 					g.printf("\tvar r%d %s\n", idx, typ)
 					g.printf("\tif ret.Get(%d) != nil {\n", idx)
 					g.printf("\t\tr%d = ret.Get(%d).(%s)\n", idx, idx, typ)
@@ -309,6 +308,14 @@ func (g *Generator) Generate() error {
 	}
 
 	return nil
+}
+
+func (g *Generator) isNillable(typ ast.Expr) bool {
+	switch typ.(type) {
+	case *ast.StarExpr, *ast.ArrayType, *ast.MapType, *ast.InterfaceType, *ast.FuncType, *ast.ChanType:
+		return true
+	}
+	return false
 }
 
 func (g *Generator) Write(w io.Writer) error {

--- a/mockery/generator_test.go
+++ b/mockery/generator_test.go
@@ -209,7 +209,10 @@ func TestGeneratorSlice(t *testing.T) {
 func (m *RequesterSlice) Get(path string) ([]string, error) {
 	ret := m.Called(path)
 
-	r0 := ret.Get(0).([]string)
+	var r0 []string
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).([]string)
+	}
 	r1 := ret.Error(1)
 
 	return r0, r1
@@ -239,7 +242,10 @@ func TestGeneratorArrayLiteralLen(t *testing.T) {
 func (m *RequesterArray) Get(path string) ([2]string, error) {
 	ret := m.Called(path)
 
-	r0 := ret.Get(0).([2]string)
+	var r0 [2]string
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).([2]string)
+	}
 	r1 := ret.Error(1)
 
 	return r0, r1
@@ -300,7 +306,10 @@ func TestGeneratorHavingNoNamesOnArguments(t *testing.T) {
 func (m *KeyManager) GetKey(_a0 string, _a1 uint16) ([]byte, *test.Err) {
 	ret := m.Called(_a0, _a1)
 
-	r0 := ret.Get(0).([]byte)
+	var r0 []byte
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).([]byte)
+	}
 	var r1 *test.Err
 	if ret.Get(1) != nil {
 		r1 = ret.Get(1).(*test.Err)
@@ -388,21 +397,30 @@ func TestGeneratorChanType(t *testing.T) {
 func (m *AsyncProducer) Input() chan<- bool {
 	ret := m.Called()
 
-	r0 := ret.Get(0).(chan<- bool)
+	var r0 chan<- bool
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(chan<- bool)
+	}
 
 	return r0
 }
 func (m *AsyncProducer) Output() <-chan bool {
 	ret := m.Called()
 
-	r0 := ret.Get(0).(<-chan bool)
+	var r0 <-chan bool
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(<-chan bool)
+	}
 
 	return r0
 }
 func (m *AsyncProducer) Whatever() chan bool {
 	ret := m.Called()
 
-	r0 := ret.Get(0).(chan bool)
+	var r0 chan bool
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(chan bool)
+	}
 
 	return r0
 }


### PR DESCRIPTION
http://golang.org/ref/spec#The_zero_value

There are 6 types for which the zero value is nil: pointers, functions, interfaces, slices, channels, and maps.