### PR TITLE
Create unexported mocks from unexported interfaces

### DIFF
--- a/mockery/fixtures/requester_unexported.go
+++ b/mockery/fixtures/requester_unexported.go
@@ -1,0 +1,5 @@
+package test
+
+type requester interface {
+	Get()
+}

--- a/mockery/generator.go
+++ b/mockery/generator.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	"golang.org/x/tools/imports"
 
@@ -50,7 +51,18 @@ func (g *Generator) GenerateIPPrologue() {
 
 func (g *Generator) mockName() string {
 	if g.ip {
-		return "Mock" + g.iface.Name
+		if ast.IsExported(g.iface.Name) {
+			return "Mock" + g.iface.Name
+		} else {
+			first := true
+			return "mock" + strings.Map(func(r rune) rune {
+				if first {
+					first = false
+					return unicode.ToUpper(r)
+				}
+				return r
+			}, g.iface.Name)
+		}
 	}
 
 	return g.iface.Name

--- a/mockery/generator_test.go
+++ b/mockery/generator_test.go
@@ -112,6 +112,30 @@ func (m *Requester4) Get() {
 	assert.Equal(t, expected, gen.buf.String())
 }
 
+func TestGeneratorUnexported(t *testing.T) {
+	parser := NewParser()
+	parser.Parse(filepath.Join(fixturePath, "requester_unexported.go"))
+
+	iface, err := parser.Find("requester")
+
+	gen := NewGenerator(iface)
+	gen.ip = true
+
+	err = gen.Generate()
+	assert.NoError(t, err)
+
+	expected := `type mockRequester struct {
+	mock.Mock
+}
+
+func (m *mockRequester) Get() {
+	m.Called()
+}
+`
+
+	assert.Equal(t, expected, gen.buf.String())
+}
+
 func TestGeneratorPrologue(t *testing.T) {
 	parser := NewParser()
 	parser.Parse(testFile)


### PR DESCRIPTION
When creating a mock with `-inpkg=true` for an unexported interface, the
generated mock should be unexported to avoid polluting the exported API
with an internal mock.

With this change, when generating a mock for `requester`, the generated
mock will be named `mockRequester` rather than `Mockrequester`.