### PR TITLE
Better file names for the output

### DIFF
--- a/cmd/mockery/mockery.go
+++ b/cmd/mockery/mockery.go
@@ -167,9 +167,9 @@ func genMock(iface *mockery.Interface) {
 		var path string
 
 		if *fIP {
-			path = filepath.Join(filepath.Dir(iface.Path), "mock_"+caseName+".go")
+			path = filepath.Join(filepath.Dir(iface.Path), filename(name, *fIP))
 		} else {
-			path = filepath.Join(*fOutput, caseName+".go")
+			path = filepath.Join(*fOutput, filename(name, *fIP))
 			os.MkdirAll(filepath.Dir(path), 0755)
 			pkg = filepath.Base(filepath.Dir(path))
 		}
@@ -216,4 +216,13 @@ func underscoreCaseName(caseName string) string {
 	s1 := rxp1.ReplaceAllString(caseName, "${1}_${2}")
 	rxp2 := regexp.MustCompile("([a-z0-9])([A-Z])")
 	return strings.ToLower(rxp2.ReplaceAllString(s1, "${1}_${2}"))
+}
+
+func filename(name string, ip bool) string {
+	name = strings.ToLower(name)
+	if ip {
+		return "mock_" + name + "_test.go"
+	} else {
+		return name + ".go"
+	}
 }

--- a/cmd/mockery/mockery.go
+++ b/cmd/mockery/mockery.go
@@ -19,6 +19,7 @@ var fOutput = flag.String("output", "./mocks", "directory to write mocks to")
 var fDir = flag.String("dir", ".", "directory to search for interfaces")
 var fAll = flag.Bool("all", false, "generates mocks for all found interfaces")
 var fIP = flag.Bool("inpkg", false, "generate a mock that goes inside the original package")
+var fTO = flag.Bool("testonly", false, "generate a mock in a _test.go file")
 var fCase = flag.String("case", "camel", "name the mocked file using casing convention")
 var fNote = flag.String("note", "", "comment to insert into prologue of each generated file")
 
@@ -167,9 +168,9 @@ func genMock(iface *mockery.Interface) {
 		var path string
 
 		if *fIP {
-			path = filepath.Join(filepath.Dir(iface.Path), filename(name, *fIP))
+			path = filepath.Join(filepath.Dir(iface.Path), filename(caseName))
 		} else {
-			path = filepath.Join(*fOutput, filename(name, *fIP))
+			path = filepath.Join(*fOutput, filename(caseName))
 			os.MkdirAll(filepath.Dir(path), 0755)
 			pkg = filepath.Base(filepath.Dir(path))
 		}
@@ -218,11 +219,12 @@ func underscoreCaseName(caseName string) string {
 	return strings.ToLower(rxp2.ReplaceAllString(s1, "${1}_${2}"))
 }
 
-func filename(name string, ip bool) string {
+func filename(name string) string {
 	name = strings.ToLower(name)
-	if ip {
+	if *fIP && *fTO {
 		return "mock_" + name + "_test.go"
-	} else {
-		return name + ".go"
+	} else if *fIP {
+		return "mock_" + name + ".go"
 	}
+	return name + ".go"
 }

--- a/cmd/mockery/mockery.go
+++ b/cmd/mockery/mockery.go
@@ -220,7 +220,6 @@ func underscoreCaseName(caseName string) string {
 }
 
 func filename(name string) string {
-	name = strings.ToLower(name)
 	if *fIP && *fTO {
 		return "mock_" + name + "_test.go"
 	} else if *fIP {

--- a/mockery_test.go
+++ b/mockery_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/bmizerany/assert"
+)
+
+func TestFilename(t *testing.T) {
+	var actual string
+
+	actual = filename("Writer", false)
+	assert.Equal(t, "writer.go", actual)
+
+	actual = filename("RoundTripper", false)
+	assert.Equal(t, "roundtripper.go", actual)
+
+	actual = filename("Writer", true)
+	assert.Equal(t, "mock_writer_test.go", actual)
+
+	actual = filename("RoundTripper", true)
+	assert.Equal(t, "mock_roundtripper_test.go", actual)
+}


### PR DESCRIPTION
Append `_test` to the -inpkg=true mocks so the file is only built for testing.

File names in lower case to be more aligned with Go's style.

Closes #20 