### PR TITLE
Fix missing mock when overridden by subpackage

### DIFF
--- a/mockery.go
+++ b/mockery.go
@@ -33,9 +33,13 @@ func checkDir(p *mockery.Parser, dir, name string) bool {
 		path := filepath.Join(dir, file.Name())
 
 		if file.IsDir() {
-			ret := checkDir(p, path, name)
-			if ret {
-				return true
+			if *fAll {
+				ret := checkDir(p, path, name)
+				if ret {
+					return true
+				}
+			} else {
+				continue
 			}
 		}
 
@@ -85,7 +89,9 @@ func walkDir(dir string) {
 		path := filepath.Join(dir, file.Name())
 
 		if file.IsDir() {
-			walkDir(path)
+			if *fAll {
+				walkDir(path)
+			}
 			continue
 		}
 


### PR DESCRIPTION
Example:
foo/interface.go //go:generate mockery -name=Interface -inpkg
foo/subpkg/interface.go //go:generate mockery -name=Interface -inpkg

go generate ./foo/...
only subpkg/mock_Interface.go was created