### PR TITLE
Add case option for generated file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ and generates mocks for any interfaces it finds.
 mockery always generates files with the package `mocks` to keep things clean and simple.
 You can control which mocks directory is used by using `-output`, which defaults to `./mocks`.
 
+## Caseing
+
+mockery generates files using the caseing of the original interface name.  This
+can be modified by specifying `-case=underscore` to format the generated file
+name using underscore casing.
+
 ### Debug
 
 Use `mockery -print` to have the resulting code printed out instead of written to disk.

--- a/mockery.go
+++ b/mockery.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/vektra/mockery/mockery"
@@ -18,6 +19,7 @@ var fOutput = flag.String("output", "./mocks", "directory to write mocks to")
 var fDir = flag.String("dir", ".", "directory to search for interfaces")
 var fAll = flag.Bool("all", false, "generates mocks for all found interfaces")
 var fIP = flag.Bool("inpkg", false, "generate a mock that goes inside the original package")
+var fCase = flag.String("case", "camel", "name the mocked file using casing convention")
 
 func checkDir(p *mockery.Parser, dir, name string) bool {
 	files, err := ioutil.ReadDir(dir)
@@ -146,6 +148,11 @@ func genMock(iface *mockery.Interface) {
 	var out io.Writer
 
 	name := iface.Name
+	caseName := iface.Name
+	if *fCase == "underscore" {
+		rxp := regexp.MustCompile("(.)([A-Z])")
+		caseName = strings.ToLower(rxp.ReplaceAllString(caseName, "$1_$2"))
+	}
 
 	if *fPrint {
 		out = os.Stdout
@@ -153,9 +160,9 @@ func genMock(iface *mockery.Interface) {
 		var path string
 
 		if *fIP {
-			path = filepath.Join(filepath.Dir(iface.Path), "mock_"+name+".go")
+			path = filepath.Join(filepath.Dir(iface.Path), "mock_"+caseName+".go")
 		} else {
-			path = filepath.Join(*fOutput, name+".go")
+			path = filepath.Join(*fOutput, caseName+".go")
 			os.MkdirAll(filepath.Dir(path), 0755)
 		}
 


### PR DESCRIPTION
When using the -inpkg option, the file names look a bit funny.

I added a option that changes to using underscore casing for the filename.

Example:
type SomethingAndOther interface
usually creates:
mock_SomethingAndOther.go
with -case=underscore we get 
mock_something_and_other.go