### PR TITLE
Use the path to determine the mocks package

### DIFF
--- a/mockery.go
+++ b/mockery.go
@@ -145,6 +145,7 @@ func genMock(iface *mockery.Interface) {
 
 	var out io.Writer
 
+	pkg := "mocks"
 	name := iface.Name
 
 	if *fPrint {
@@ -157,6 +158,7 @@ func genMock(iface *mockery.Interface) {
 		} else {
 			path = filepath.Join(*fOutput, name+".go")
 			os.MkdirAll(filepath.Dir(path), 0755)
+			pkg = filepath.Base(filepath.Dir(path))
 		}
 
 		f, err := os.Create(path)
@@ -177,7 +179,7 @@ func genMock(iface *mockery.Interface) {
 	if *fIP {
 		gen.GenerateIPPrologue()
 	} else {
-		gen.GeneratePrologue()
+		gen.GeneratePrologue(pkg)
 	}
 
 	err := gen.Generate()

--- a/mockery/generator.go
+++ b/mockery/generator.go
@@ -68,8 +68,8 @@ func (g *Generator) mockName() string {
 	return g.iface.Name
 }
 
-func (g *Generator) GeneratePrologue() {
-	g.printf("package mocks\n\n")
+func (g *Generator) GeneratePrologue(pkg string) {
+	g.printf("package %v\n\n", pkg)
 
 	goPath := os.Getenv("GOPATH")
 


### PR DESCRIPTION
When I specify -output=./mock -all
I expect the package to be named mock and not mocks.

This adds a override to the package name for that case.