### PR TITLE
Return Value Provider Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,16 @@ type Stringer struct {
 }
 
 func (m *Stringer) String() string {
- ret := m.Called()
+	ret := m.Called()
 
- r0 := ret.Get(0).(string)
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0)
+	}
 
- return r0
+	return r0
 }
 ```
 
@@ -49,6 +54,32 @@ package to remove any unnecessary imports (as they'd result in compile errors).
 ### Types
 
 mockery should handle all types. If you find it does not, please report the issue.
+
+### Return Value Provider Functions
+
+If your tests need access to the arguments to calculate the return values,
+set the return value to a function that takes the method's arguments as its own
+arguments and returns the return value. For example, given this interface:
+
+```go
+package test
+
+type Proxy interface {
+  passthrough(s string) string
+}
+```
+
+The argument can be passed through as the return value:
+
+```
+Mock.On("passthrough").Return(func(s string) string) {
+    return s
+})
+```
+
+Note, this approach should be used judiciously, as return values should generally 
+not depend on arguments in mocks; however, this approach can be helpful for 
+situations like passthroughs or other test-only calculations.
 
 ### All
 

--- a/mockery/fixtures/func_type.go
+++ b/mockery/fixtures/func_type.go
@@ -3,4 +3,5 @@ package test
 type Fooer interface {
 	Foo(f func(x string) string) error
 	Bar(f func([]int))
+	Baz(path string) func(x string) string
 }

--- a/mockery/generator.go
+++ b/mockery/generator.go
@@ -278,42 +278,46 @@ func (g *Generator) Generate() error {
 
 		fname := method.Names[0].Name
 
-		names, _, params := g.genList(ftype.Params, true)
-		_, types, returs := g.genList(ftype.Results, false)
+		paramNames, paramTypes, params := g.genList(ftype.Params, true)
+		_, returnTypes, returns := g.genList(ftype.Results, false)
 
 		g.printf("func (m *%s) %s(%s) ", g.mockName(), fname, strings.Join(params, ", "))
 
-		switch len(returs) {
+		switch len(returns) {
 		case 0:
 			g.printf("{\n")
 		case 1:
-			g.printf("%s {\n", returs[0])
+			g.printf("%s {\n", returns[0])
 		default:
-			g.printf("(%s) {\n", strings.Join(returs, ", "))
+			g.printf("(%s) {\n", strings.Join(returns, ", "))
 		}
-		if len(types) > 0 {
-			g.printf("\tret := m.Called(%s)\n\n", strings.Join(names, ", "))
+		if len(returnTypes) > 0 {
+			g.printf("\tret := m.Called(%s)\n\n", strings.Join(paramNames, ", "))
 
 			var ret []string
 
-			for idx, typ := range types {
+			for idx, typ := range returnTypes {
+				g.printf("\tvar r%d %s\n", idx, typ)
+				g.printf("\tif rf, ok := ret.Get(%d).(func(%s) %s); ok {\n", idx, strings.Join(paramTypes, ", "), typ)
+				g.printf("\t\tr%d = rf(%s)\n", idx, strings.Join(paramNames, ", "))
+				g.printf("\t} else {\n")
 				if typ == "error" {
-					g.printf("\tr%d := ret.Error(%d)\n", idx, idx)
+					g.printf("\t\tr%d = ret.Error(%d)\n", idx, idx)
 				} else if g.isNillable(ftype.Results.List[idx].Type) {
-					g.printf("\tvar r%d %s\n", idx, typ)
-					g.printf("\tif ret.Get(%d) != nil {\n", idx)
-					g.printf("\t\tr%d = ret.Get(%d).(%s)\n", idx, idx, typ)
-					g.printf("\t}\n")
+					g.printf("\t\tif ret.Get(%d) != nil {\n", idx)
+					g.printf("\t\t\tr%d = ret.Get(%d).(%s)\n", idx, idx, typ)
+					g.printf("\t\t}\n")
 				} else {
-					g.printf("\tr%d := ret.Get(%d).(%s)\n", idx, idx, typ)
+					g.printf("\t\tr%d = ret.Get(%d).(%s)\n", idx, idx, typ)
 				}
+				g.printf("\t}\n\n")
 				ret = append(ret, fmt.Sprintf("r%d", idx))
 			}
 
-			g.printf("\n\treturn %s\n", strings.Join(ret, ", "))
+			g.printf("\treturn %s\n", strings.Join(ret, ", "))
 
 		} else {
-			g.printf("\tm.Called(%s)\n", strings.Join(names, ", "))
+			g.printf("\tm.Called(%s)\n", strings.Join(paramNames, ", "))
 		}
 
 		g.printf("}\n")

--- a/mockery/generator_test.go
+++ b/mockery/generator_test.go
@@ -25,8 +25,19 @@ func TestGenerator(t *testing.T) {
 func (m *Requester) Get(path string) (string, error) {
 	ret := m.Called(path)
 
-	r0 := ret.Get(0).(string)
-	r1 := ret.Error(1)
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
@@ -53,7 +64,12 @@ func TestGeneratorSingleReturn(t *testing.T) {
 func (m *Requester2) Get(path string) error {
 	ret := m.Called(path)
 
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Error(0)
+	}
 
 	return r0
 }
@@ -80,7 +96,12 @@ func TestGeneratorNoArguments(t *testing.T) {
 func (m *Requester3) Get() error {
 	ret := m.Called()
 
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
 
 	return r0
 }
@@ -145,7 +166,7 @@ func TestGeneratorPrologue(t *testing.T) {
 
 	gen := NewGenerator(iface)
 
-	gen.GeneratePrologue()
+	gen.GeneratePrologue("mocks")
 
 	expected := `package mocks
 
@@ -166,7 +187,7 @@ func TestGeneratorProloguewithImports(t *testing.T) {
 
 	gen := NewGenerator(iface)
 
-	gen.GeneratePrologue()
+	gen.GeneratePrologue("mocks")
 
 	expected := `package mocks
 
@@ -201,10 +222,20 @@ func (m *RequesterPtr) Get(path string) (*string, error) {
 	ret := m.Called(path)
 
 	var r0 *string
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).(*string)
+	if rf, ok := ret.Get(0).(func(string) *string); ok {
+		r0 = rf(path)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*string)
+		}
 	}
-	r1 := ret.Error(1)
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
@@ -234,10 +265,20 @@ func (m *RequesterSlice) Get(path string) ([]string, error) {
 	ret := m.Called(path)
 
 	var r0 []string
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]string)
+	if rf, ok := ret.Get(0).(func(string) []string); ok {
+		r0 = rf(path)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
 	}
-	r1 := ret.Error(1)
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
@@ -267,10 +308,20 @@ func (m *RequesterArray) Get(path string) ([2]string, error) {
 	ret := m.Called(path)
 
 	var r0 [2]string
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([2]string)
+	if rf, ok := ret.Get(0).(func(string) [2]string); ok {
+		r0 = rf(path)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([2]string)
+		}
 	}
-	r1 := ret.Error(1)
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
@@ -299,8 +350,19 @@ func TestGeneratorNamespacedTypes(t *testing.T) {
 func (m *RequesterNS) Get(path string) (http.Response, error) {
 	ret := m.Called(path)
 
-	r0 := ret.Get(0).(http.Response)
-	r1 := ret.Error(1)
+	var r0 http.Response
+	if rf, ok := ret.Get(0).(func(string) http.Response); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(http.Response)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
@@ -331,12 +393,21 @@ func (m *KeyManager) GetKey(_a0 string, _a1 uint16) ([]byte, *test.Err) {
 	ret := m.Called(_a0, _a1)
 
 	var r0 []byte
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]byte)
+	if rf, ok := ret.Get(0).(func(string, uint16) []byte); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
 	}
+
 	var r1 *test.Err
-	if ret.Get(1) != nil {
-		r1 = ret.Get(1).(*test.Err)
+	if rf, ok := ret.Get(1).(func(string, uint16) *test.Err); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*test.Err)
+		}
 	}
 
 	return r0, r1
@@ -364,7 +435,12 @@ func TestGeneratorElidedType(t *testing.T) {
 func (m *RequesterElided) Get(path string, url string) error {
 	ret := m.Called(path, url)
 
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(path, url)
+	} else {
+		r0 = ret.Error(0)
+	}
 
 	return r0
 }
@@ -391,12 +467,31 @@ func TestGeneratorFuncType(t *testing.T) {
 func (m *Fooer) Foo(f func(string) string) error {
 	ret := m.Called(f)
 
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(func(string) string) error); ok {
+		r0 = rf(f)
+	} else {
+		r0 = ret.Error(0)
+	}
 
 	return r0
 }
 func (m *Fooer) Bar(f func([]int) ) {
 	m.Called(f)
+}
+func (m *Fooer) Baz(path string) func(string) string {
+	ret := m.Called(path)
+
+	var r0 func(string) string
+	if rf, ok := ret.Get(0).(func(string) func(string) string); ok {
+		r0 = rf(path)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(func(string) string)
+		}
+	}
+
+	return r0
 }
 `
 
@@ -422,8 +517,12 @@ func (m *AsyncProducer) Input() chan<- bool {
 	ret := m.Called()
 
 	var r0 chan<- bool
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).(chan<- bool)
+	if rf, ok := ret.Get(0).(func() chan<- bool); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(chan<- bool)
+		}
 	}
 
 	return r0
@@ -432,8 +531,12 @@ func (m *AsyncProducer) Output() <-chan bool {
 	ret := m.Called()
 
 	var r0 <-chan bool
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).(<-chan bool)
+	if rf, ok := ret.Get(0).(func() <-chan bool); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(<-chan bool)
+		}
 	}
 
 	return r0
@@ -442,8 +545,12 @@ func (m *AsyncProducer) Whatever() chan bool {
 	ret := m.Called()
 
 	var r0 chan bool
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).(chan bool)
+	if rf, ok := ret.Get(0).(func() chan bool); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(chan bool)
+		}
 	}
 
 	return r0


### PR DESCRIPTION
This adds optional support for mocks to use functions to provide the
return values at test time from arguments. This is a backward compatible
change and still supports standard return values. See [docs](https://github.com/ryanbrainard/mockery/blob/59ab6b5153d59cb24e5b9472a6bec1c093c3d382/README.md#return-value-provider-functions) for an example of how this can be used.