### PR TITLE
Add option for prologue note

### DIFF
--- a/mockery.go
+++ b/mockery.go
@@ -20,6 +20,7 @@ var fDir = flag.String("dir", ".", "directory to search for interfaces")
 var fAll = flag.Bool("all", false, "generates mocks for all found interfaces")
 var fIP = flag.Bool("inpkg", false, "generate a mock that goes inside the original package")
 var fCase = flag.String("case", "camel", "name the mocked file using casing convention")
+var fNote = flag.String("note", "", "comment to insert into prologue of each generated file")
 
 func checkDir(p *mockery.Parser, dir, name string) bool {
 	files, err := ioutil.ReadDir(dir)
@@ -194,6 +195,8 @@ func genMock(iface *mockery.Interface) {
 	} else {
 		gen.GeneratePrologue(pkg)
 	}
+
+	gen.GeneratePrologueNote(*fNote)
 
 	err := gen.Generate()
 	if err != nil {

--- a/mockery/generator.go
+++ b/mockery/generator.go
@@ -96,6 +96,16 @@ func (g *Generator) GeneratePrologue(pkg string) {
 	g.printf("\n")
 }
 
+func (g *Generator) GeneratePrologueNote(note string) {
+	if note != "" {
+		g.printf("\n")
+		for _, n := range strings.Split(note, "\\n") {
+				g.printf("// %s\n", n)
+		}
+		g.printf("\n")
+	}
+}
+
 var ErrNotInterface = errors.New("expression not an interface")
 
 func (g *Generator) printf(s string, vals ...interface{}) {
@@ -331,7 +341,7 @@ func (g *Generator) isNillable(typ ast.Expr) bool {
 }
 
 func (g *Generator) Write(w io.Writer) error {
-	opt := &imports.Options{}
+	opt := &imports.Options{Comments: true}
 	res, err := imports.Process("mock.go", g.buf.Bytes(), opt)
 	if err != nil {
 		return err

--- a/mockery/generator_test.go
+++ b/mockery/generator_test.go
@@ -180,6 +180,26 @@ import "net/http"
 	assert.Equal(t, expected, gen.buf.String())
 }
 
+func TestGeneratorPrologueNote(t *testing.T) {
+	parser := NewParser()
+	parser.Parse(testFile)
+
+	iface, err := parser.Find("Requester")
+	assert.NoError(t, err)
+
+	gen := NewGenerator(iface)
+
+	gen.GeneratePrologueNote("A\\nB")
+
+	expected := `
+// A
+// B
+
+`
+
+	assert.Equal(t, expected, gen.buf.String())
+}
+
 func TestGeneratorPointers(t *testing.T) {
 	parser := NewParser()
 	parser.Parse(filepath.Join(fixturePath, "requester_ptr.go"))


### PR DESCRIPTION
This adds an option for inserting a note in the prologue of generated mocks. This can be useful to stamp all files as auto-generated with instructions how to re-generate, copyrights, or any other boilerplate commentary. For example:

    mockery -all -note "AUTO-GENERATED MOCK. DO NOT EDIT.\nUSE make mocks TO REGENERATE."

Results in a prologue that looks like this:

```
package mocks

import "github.com/stretchr/testify/mock"

// AUTO-GENERATED MOCK. DO NOT EDIT.
// USE make mocks TO REGENERATE.
```