### PR TITLE
Add -recursive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,14 @@ situations like passthroughs or other test-only calculations.
 
 It's common for a big package to have a lot of interfaces, so mockery provides `-all`.
 This option will tell mockery to scan all files under the directory named by `-dir` ("." by default)
-and generates mocks for any interfaces it finds.
+and generates mocks for any interfaces it finds. To include subdirectories, also use `-recursive`.
 
 `-all` was designed to be able to be used automatically in the background if required.
+
+### Recursive
+
+Use the `-recursive` option to search subdirectories for the interface(s).
+Compatible with either `-name` or `-all`.
 
 ### Output
 

--- a/README.md
+++ b/README.md
@@ -81,18 +81,22 @@ Note, this approach should be used judiciously, as return values should generall
 not depend on arguments in mocks; however, this approach can be helpful for 
 situations like passthroughs or other test-only calculations.
 
+### Name
+
+The `-name` option takes either the name or matching regular expression of interface to generate mock(s) for.
+
 ### All
 
 It's common for a big package to have a lot of interfaces, so mockery provides `-all`.
 This option will tell mockery to scan all files under the directory named by `-dir` ("." by default)
-and generates mocks for any interfaces it finds. To include subdirectories, also use `-recursive`.
+and generates mocks for any interfaces it finds. This option implies `-recursive=true`.
 
 `-all` was designed to be able to be used automatically in the background if required.
 
 ### Recursive
 
 Use the `-recursive` option to search subdirectories for the interface(s).
-Compatible with either `-name` or `-all`.
+This option is only compatible with `-name`. The `-all` option implies `-recursive=true`.
 
 ### Output
 

--- a/cmd/mockery/mockery.go
+++ b/cmd/mockery/mockery.go
@@ -13,12 +13,14 @@ import (
 	"github.com/vektra/mockery/mockery"
 )
 
-var fName = flag.String("name", "", "name of interface to generate mock for")
+const regexMetadataChars = "\\.+*?()|[]{}^$"
+
+var fName = flag.String("name", "", "name or matching regular expression of interface to generate mock for")
 var fPrint = flag.Bool("print", false, "print the generated mock to stdout")
 var fOutput = flag.String("output", "./mocks", "directory to write mocks to")
 var fDir = flag.String("dir", ".", "directory to search for interfaces")
-var fRecursive = flag.Bool("recursive", false, "recurse into child directories")
-var fAll = flag.Bool("all", false, "generates mocks for all found interfaces")
+var fRecursive = flag.Bool("recursive", false, "recurse search into sub-directories")
+var fAll = flag.Bool("all", false, "generates mocks for all found interfaces in all sub-directories")
 var fIP = flag.Bool("inpkg", false, "generate a mock that goes inside the original package")
 var fTO = flag.Bool("testonly", false, "generate a mock in a _test.go file")
 var fCase = flag.String("case", "camel", "name the mocked file using casing convention")
@@ -27,12 +29,34 @@ var fNote = flag.String("note", "", "comment to insert into prologue of each gen
 func main() {
 	flag.Parse()
 
-	if *fName == "" && !*fAll {
-		fmt.Fprintf(os.Stderr, "Use -name to specify the name of the interface or -all for all interfaces found\n")
+	var recursive bool
+	var filter *regexp.Regexp
+	var err error
+	var limitOne bool
+
+	if *fName != "" && *fAll {
+		fmt.Fprintln(os.Stderr, "Specify -name or -all, but not both")
+		os.Exit(1)
+	} else if *fName != "" {
+		recursive = *fRecursive
+		if strings.ContainsAny(*fName, regexMetadataChars) {
+			if filter, err = regexp.Compile(*fName); err != nil {
+				fmt.Fprintln(os.Stderr, "Invalid regular expression provided to -name")
+				os.Exit(1)
+			}
+		} else {
+			filter = regexp.MustCompile(fmt.Sprintf("^%s$", *fName))
+			limitOne = true
+		}
+	} else if *fAll {
+		recursive = true
+		filter = regexp.MustCompile(".*")
+	} else {
+		fmt.Fprintln(os.Stderr, "Use -name to specify the name of the interface or -all for all interfaces found")
 		os.Exit(1)
 	}
 
-	generated := walkDir(*fDir)
+	generated := walkDir(*fDir, recursive, filter, limitOne)
 
 	if *fName != "" && !generated {
 		fmt.Printf("Unable to find %s in any go files under this path\n", *fName)
@@ -40,7 +64,7 @@ func main() {
 	}
 }
 
-func walkDir(dir string) (generated bool) {
+func walkDir(dir string, recursive bool, filter *regexp.Regexp, limitOne bool) (generated bool) {
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return
@@ -54,9 +78,9 @@ func walkDir(dir string) (generated bool) {
 		path := filepath.Join(dir, file.Name())
 
 		if file.IsDir() {
-			if *fRecursive {
-				generated = walkDir(path) || generated
-				if generated && *fName != "" {
+			if recursive {
+				generated = walkDir(path, recursive, filter, limitOne) || generated
+				if generated && limitOne {
 					return
 				}
 			}
@@ -75,12 +99,12 @@ func walkDir(dir string) (generated bool) {
 		}
 
 		for _, iface := range p.Interfaces() {
-			if *fName != "" && *fName != iface.Name {
+			if !filter.MatchString(iface.Name) {
 				continue
 			}
 			genMock(iface)
 			generated = true
-			if *fName != "" {
+			if limitOne {
 				return
 			}
 		}


### PR DESCRIPTION
This unifies `-name` and `-all` to both not be recurse by default, but provides the option to do so. 

Previously ,`-name` was never recursed, while `-all` was always recursed. This change is helpful for  finding either a specific interface name in a multi-package project or limiting the depth of `-all`. This also simplifies the code a bit, as `checkDir` and `mockFor` are no longer needed.

This is a slight breaking change. Users depending on the previously recursive behavior of `-all` will need to add use `-recursive` to traverse into subdirectories.