### PR TITLE
Fixes bug #31, wrong filenames with option case=underscore

### DIFF
--- a/cmd/mockery/mockery.go
+++ b/cmd/mockery/mockery.go
@@ -158,8 +158,7 @@ func genMock(iface *mockery.Interface) {
 	name := iface.Name
 	caseName := iface.Name
 	if *fCase == "underscore" {
-		rxp := regexp.MustCompile("(.)([A-Z])")
-		caseName = strings.ToLower(rxp.ReplaceAllString(caseName, "$1_$2"))
+		caseName = underscoreCaseName(caseName)
 	}
 
 	if *fPrint {
@@ -209,4 +208,12 @@ func genMock(iface *mockery.Interface) {
 		fmt.Printf("Error writing %s: %s\n", name, err)
 		os.Exit(1)
 	}
+}
+
+// shamelessly taken from http://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-camel-caseo
+func underscoreCaseName(caseName string) string {
+	rxp1 := regexp.MustCompile("(.)([A-Z][a-z]+)")
+	s1 := rxp1.ReplaceAllString(caseName, "${1}_${2}")
+	rxp2 := regexp.MustCompile("([a-z0-9])([A-Z])")
+	return strings.ToLower(rxp2.ReplaceAllString(s1, "${1}_${2}"))
 }

--- a/cmd/mockery/mockery_test.go
+++ b/cmd/mockery/mockery_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnderscoreCaseName(t *testing.T) {
+	assert.Equal(t, "notify_event", underscoreCaseName("NotifyEvent"))
+	assert.Equal(t, "repository", underscoreCaseName("Repository"))
+	assert.Equal(t, "http_server", underscoreCaseName("HTTPServer"))
+	assert.Equal(t, "awesome_http_server", underscoreCaseName("AwesomeHTTPServer"))
+	assert.Equal(t, "csv", underscoreCaseName("CSV"))
+	assert.Equal(t, "position0_size", underscoreCaseName("Position0Size"))
+}


### PR DESCRIPTION
The following cases are tested:

* NotifyEvent -> notify_event
* Repository -> repository
* HTTPServer -> http_server
* AwesomeHTTPServer -> awesome_http_server
* CSV -> csv
* Position0Size -> position0_size