### PR TITLE
Update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ the boilerplate coding required to use mocks.
 
 ### Installation
 
-`go get github.com/vektra/mockery`, then `$GOPATH/bin/mockery`
+`go get github.com/vektra/mockery/.../`, then `$GOPATH/bin/mockery`
 
 ### Example
 


### PR DESCRIPTION
In ee70206caf754c761346b92fec89352f0e21027c `package main` was moved into a subdirectory.  The install steps in the README assume `go get` will build the binary, which is no longer correct now that the main package is outside the repo root.  There may be better ways to fix this, but as the most user friendly possibility I'd suggest appending the `/.../` wildcard notation to the `go get` package argument so that it will see the subpackage and build it.  Another option would be to add a second `go install` step after the `go get`, eg:
`go install github.com/vektra/mockery/cmd/mockery/`