### PR TITLE
Add support for multiple named return variables of the same type

### DIFF
--- a/mockery/fixtures/requester_ret_elided.go
+++ b/mockery/fixtures/requester_ret_elided.go
@@ -1,0 +1,5 @@
+package test
+
+type RequesterReturnElided interface {
+	Get(path string) (a, b int, err error)
+}

--- a/mockery/generator.go
+++ b/mockery/generator.go
@@ -240,12 +240,22 @@ func (g *Generator) genList(list *ast.FieldList, addNames bool) ([]string, []str
 		return params, names, types
 	}
 
+	elided := false
+	if !addNames {
+		for _, param := range list.List {
+			if len(param.Names) > 1 {
+				elided = true
+				break
+			}
+		}
+	}
+
 	for idx, param := range list.List {
 		ts := g.typeString(param.Type)
 
 		var pname string
 
-		if addNames {
+		if addNames || elided {
 			if len(param.Names) == 0 {
 				pname = fmt.Sprintf("_a%d", idx)
 				names = append(names, pname)

--- a/mockery/generator.go
+++ b/mockery/generator.go
@@ -240,11 +240,10 @@ func (g *Generator) genList(list *ast.FieldList, addNames bool) ([]string, []str
 		return params, names, types
 	}
 
-	elided := false
 	if !addNames {
 		for _, param := range list.List {
 			if len(param.Names) > 1 {
-				elided = true
+				addNames = true
 				break
 			}
 		}
@@ -255,7 +254,7 @@ func (g *Generator) genList(list *ast.FieldList, addNames bool) ([]string, []str
 
 		var pname string
 
-		if addNames || elided {
+		if addNames {
 			if len(param.Names) == 0 {
 				pname = fmt.Sprintf("_a%d", idx)
 				names = append(names, pname)

--- a/mockery/generator_test.go
+++ b/mockery/generator_test.go
@@ -469,6 +469,52 @@ func (_m *RequesterElided) Get(path string, url string) error {
 	assert.Equal(t, expected, gen.buf.String())
 }
 
+func TestGeneratorReturnElidedType(t *testing.T) {
+	parser := NewParser()
+	parser.Parse(filepath.Join(fixturePath, "requester_ret_elided.go"))
+
+	iface, err := parser.Find("RequesterReturnElided")
+
+	gen := NewGenerator(iface)
+
+	err = gen.Generate()
+	assert.NoError(t, err)
+
+	expected := `type RequesterReturnElided struct {
+	mock.Mock
+}
+
+func (_m *RequesterReturnElided) Get(path string) (a int, b int, err error) {
+	ret := _m.Called(path)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(string) int); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 int
+	if rf, ok := ret.Get(1).(func(string) int); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(string) error); ok {
+		r2 = rf(path)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+`
+
+	assert.Equal(t, expected, gen.buf.String())
+}
+
 func TestGeneratorVariableArgs(t *testing.T) {
 
 	parser := NewParser()


### PR DESCRIPTION
Fix bug where the mock method signature for a function with multiple
named return variables of the same type is not generated correctly.