### PR TITLE
Seperate config parsing from main

### DIFF
--- a/cmd/mockery/mockery.go
+++ b/cmd/mockery/mockery.go
@@ -90,7 +90,7 @@ func walkDir(config Config, dir string, recursive bool, filter *regexp.Regexp, l
 			continue
 		}
 
-		path := filepath.Join(dir, file.Name())
+		path := filepath.Join(config.fDir, file.Name())
 
 		if file.IsDir() {
 			if recursive {

--- a/cmd/mockery/mockery_test.go
+++ b/cmd/mockery/mockery_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"strings"
 )
 
 func TestUnderscoreCaseName(t *testing.T) {
@@ -29,4 +30,36 @@ func TestFilenameMockTest(t *testing.T) {
 
 func TestFilenameTest(t *testing.T) {
 	assert.Equal(t, "name_test.go", filename("name", Config{fIP: false, fTO: true}))
+}
+
+func configFromCommandLine(str string) Config {
+	return parseConfigFromArgs(strings.Split(str, " "))
+}
+
+func TestParseConfigDefaults(t *testing.T) {
+	config := configFromCommandLine("mockery")
+	assert.Equal(t, "", config.fName)
+	assert.Equal(t, false, config.fPrint)
+	assert.Equal(t, "./mocks", config.fOutput)
+	assert.Equal(t, ".", config.fDir)
+	assert.Equal(t, false, config.fRecursive)
+	assert.Equal(t, false, config.fAll)
+	assert.Equal(t, false, config.fIP)
+	assert.Equal(t, false, config.fTO)
+	assert.Equal(t, "camel", config.fCase)
+	assert.Equal(t, "", config.fNote)
+}
+
+func TestParseConfigFlippingValues(t *testing.T) {
+	config := configFromCommandLine("mockery -name hi -print -output output -dir dir -recursive -all -inpkg -testonly -case case -note note")
+	assert.Equal(t, "hi", config.fName)
+	assert.Equal(t, true, config.fPrint)
+	assert.Equal(t, "output", config.fOutput)
+	assert.Equal(t, "dir", config.fDir)
+	assert.Equal(t, true, config.fRecursive)
+	assert.Equal(t, true, config.fAll)
+	assert.Equal(t, true, config.fIP)
+	assert.Equal(t, true, config.fTO)
+	assert.Equal(t, "case", config.fCase)
+	assert.Equal(t, "note", config.fNote)
 }


### PR DESCRIPTION
Moving config parsing out to it's own function to make it easier to add complicated command line flags like repeating ones in #51 