### PR TITLE
Move output from main

### DIFF
--- a/cmd/mockery/mockery.go
+++ b/cmd/mockery/mockery.go
@@ -90,7 +90,7 @@ func walkDir(config Config, dir string, recursive bool, filter *regexp.Regexp, l
 			continue
 		}
 
-		path := filepath.Join(dir, file.Name())
+		path := filepath.Join(config.fDir, file.Name())
 
 		if file.IsDir() {
 			if recursive {

--- a/cmd/mockery/mockery_test.go
+++ b/cmd/mockery/mockery_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"strings"
 )
 
 func TestUnderscoreCaseName(t *testing.T) {
@@ -29,4 +30,36 @@ func TestFilenameMockTest(t *testing.T) {
 
 func TestFilenameTest(t *testing.T) {
 	assert.Equal(t, "name_test.go", filename("name", Config{fIP: false, fTO: true}))
+}
+
+func configFromCommandLine(str string) Config {
+	return parseConfigFromArgs(strings.Split(str, " "))
+}
+
+func TestParseConfigDefaults(t *testing.T) {
+	config := configFromCommandLine("mockery")
+	assert.Equal(t, "", config.fName)
+	assert.Equal(t, false, config.fPrint)
+	assert.Equal(t, "./mocks", config.fOutput)
+	assert.Equal(t, ".", config.fDir)
+	assert.Equal(t, false, config.fRecursive)
+	assert.Equal(t, false, config.fAll)
+	assert.Equal(t, false, config.fIP)
+	assert.Equal(t, false, config.fTO)
+	assert.Equal(t, "camel", config.fCase)
+	assert.Equal(t, "", config.fNote)
+}
+
+func TestParseConfigFlippingValues(t *testing.T) {
+	config := configFromCommandLine("mockery -name hi -print -output output -dir dir -recursive -all -inpkg -testonly -case case -note note")
+	assert.Equal(t, "hi", config.fName)
+	assert.Equal(t, true, config.fPrint)
+	assert.Equal(t, "output", config.fOutput)
+	assert.Equal(t, "dir", config.fDir)
+	assert.Equal(t, true, config.fRecursive)
+	assert.Equal(t, true, config.fAll)
+	assert.Equal(t, true, config.fIP)
+	assert.Equal(t, true, config.fTO)
+	assert.Equal(t, "case", config.fCase)
+	assert.Equal(t, "note", config.fNote)
 }

--- a/cmd/mockery/mockery_test.go
+++ b/cmd/mockery/mockery_test.go
@@ -7,31 +7,6 @@ import (
 	"strings"
 )
 
-func TestUnderscoreCaseName(t *testing.T) {
-	assert.Equal(t, "notify_event", underscoreCaseName("NotifyEvent"))
-	assert.Equal(t, "repository", underscoreCaseName("Repository"))
-	assert.Equal(t, "http_server", underscoreCaseName("HTTPServer"))
-	assert.Equal(t, "awesome_http_server", underscoreCaseName("AwesomeHTTPServer"))
-	assert.Equal(t, "csv", underscoreCaseName("CSV"))
-	assert.Equal(t, "position0_size", underscoreCaseName("Position0Size"))
-}
-
-func TestFilenameBare(t *testing.T) {
-	assert.Equal(t, "name.go", filename("name", Config{fIP: false, fTO: false}))
-}
-
-func TestFilenameMockOnly(t *testing.T) {
-	assert.Equal(t, "mock_name.go", filename("name", Config{fIP: true, fTO: false}))
-}
-
-func TestFilenameMockTest(t *testing.T) {
-	assert.Equal(t, "mock_name_test.go", filename("name", Config{fIP: true, fTO: true}))
-}
-
-func TestFilenameTest(t *testing.T) {
-	assert.Equal(t, "name_test.go", filename("name", Config{fIP: false, fTO: true}))
-}
-
 func configFromCommandLine(str string) Config {
 	return parseConfigFromArgs(strings.Split(str, " "))
 }

--- a/mockery/outputter.go
+++ b/mockery/outputter.go
@@ -1,0 +1,78 @@
+package mockery
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type Cleanup func() error
+
+type OutputStreamProvider interface {
+	GetWriter(iface *Interface, pkg string) (io.Writer, error, Cleanup)
+}
+
+type StdoutStreamProvider struct {
+}
+
+func (this *StdoutStreamProvider) GetWriter(iface *Interface, pkg string) (io.Writer, error, Cleanup) {
+	return os.Stdout, nil, func() error { return nil }
+}
+
+type FileOutputStreamProvider struct {
+	BaseDir   string
+	InPackage bool
+	TestOnly  bool
+	Case      string
+}
+
+func (this *FileOutputStreamProvider) GetWriter(iface *Interface, pkg string) (io.Writer, error, Cleanup) {
+	var path string
+
+	caseName := iface.Name
+	if this.Case == "underscore" {
+		caseName = this.underscoreCaseName(caseName)
+	}
+
+	if this.InPackage {
+		path = filepath.Join(filepath.Dir(iface.Path), this.filename(caseName))
+	} else {
+		path = filepath.Join(this.BaseDir, this.filename(caseName))
+		os.MkdirAll(filepath.Dir(path), 0755)
+		pkg = filepath.Base(filepath.Dir(path))
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err, func() error { return nil }
+	}
+
+	defer f.Close()
+
+	fmt.Printf("Generating mock for: %s\n", iface.Name)
+	return f, nil, func() error {
+		return f.Close()
+	}
+}
+
+func (this *FileOutputStreamProvider) filename(name string) string {
+	if this.InPackage && this.TestOnly {
+		return "mock_" + name + "_test.go"
+	} else if this.InPackage {
+		return "mock_" + name + ".go"
+	} else if this.TestOnly {
+		return name + "_test.go"
+	}
+	return name + ".go"
+}
+
+// shamelessly taken from http://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-camel-caseo
+func (this *FileOutputStreamProvider) underscoreCaseName(caseName string) string {
+	rxp1 := regexp.MustCompile("(.)([A-Z][a-z]+)")
+	s1 := rxp1.ReplaceAllString(caseName, "${1}_${2}")
+	rxp2 := regexp.MustCompile("([a-z0-9])([A-Z])")
+	return strings.ToLower(rxp2.ReplaceAllString(s1, "${1}_${2}"))
+}

--- a/mockery/outputter_test.go
+++ b/mockery/outputter_test.go
@@ -1,0 +1,36 @@
+package mockery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilenameBare(t *testing.T) {
+	out := FileOutputStreamProvider{InPackage: false, TestOnly: false}
+	assert.Equal(t, "name.go", out.filename("name"))
+}
+
+func TestFilenameMockOnly(t *testing.T) {
+	out := FileOutputStreamProvider{InPackage: true, TestOnly: false}
+	assert.Equal(t, "mock_name.go", out.filename("name"))
+}
+
+func TestFilenameMockTest(t *testing.T) {
+	out := FileOutputStreamProvider{InPackage: true, TestOnly: true}
+	assert.Equal(t, "mock_name_test.go", out.filename("name"))
+}
+
+func TestFilenameTest(t *testing.T) {
+	out := FileOutputStreamProvider{InPackage: false, TestOnly: true}
+	assert.Equal(t, "name_test.go", out.filename("name"))
+}
+
+func TestUnderscoreCaseName(t *testing.T) {
+	assert.Equal(t, "notify_event", (&FileOutputStreamProvider{}).underscoreCaseName("NotifyEvent"))
+	assert.Equal(t, "repository", (&FileOutputStreamProvider{}).underscoreCaseName("Repository"))
+	assert.Equal(t, "http_server", (&FileOutputStreamProvider{}).underscoreCaseName("HTTPServer"))
+	assert.Equal(t, "awesome_http_server", (&FileOutputStreamProvider{}).underscoreCaseName("AwesomeHTTPServer"))
+	assert.Equal(t, "csv", (&FileOutputStreamProvider{}).underscoreCaseName("CSV"))
+	assert.Equal(t, "position0_size", (&FileOutputStreamProvider{}).underscoreCaseName("Position0Size"))
+}


### PR DESCRIPTION
This follows on from #62.

Moves the output stream creation into it's own type / interface and simplifies some of the creation logic into types. This will lead to being able to moving out a "walker" and a "generator". The interface also means we can mock test these types independent of the filesystem.