### PR TITLE
Pull all generation logic from mockery.go, which now only deals with command line args and setting up the generate.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 SHELL=bash
 
-all: fmt test install integration
+all: clean fmt test install integration
+
+clean:
+	rm -rf mocks
 
 fmt:
 	go fmt ./...

--- a/cmd/mockery/mockery.go
+++ b/cmd/mockery/mockery.go
@@ -90,7 +90,7 @@ func walkDir(config Config, dir string, recursive bool, filter *regexp.Regexp, l
 			continue
 		}
 
-		path := filepath.Join(dir, file.Name())
+		path := filepath.Join(config.fDir, file.Name())
 
 		if file.IsDir() {
 			if recursive {

--- a/cmd/mockery/mockery_test.go
+++ b/cmd/mockery/mockery_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"strings"
 )
 
 func TestUnderscoreCaseName(t *testing.T) {
@@ -29,4 +30,36 @@ func TestFilenameMockTest(t *testing.T) {
 
 func TestFilenameTest(t *testing.T) {
 	assert.Equal(t, "name_test.go", filename("name", Config{fIP: false, fTO: true}))
+}
+
+func configFromCommandLine(str string) Config {
+	return parseConfigFromArgs(strings.Split(str, " "))
+}
+
+func TestParseConfigDefaults(t *testing.T) {
+	config := configFromCommandLine("mockery")
+	assert.Equal(t, "", config.fName)
+	assert.Equal(t, false, config.fPrint)
+	assert.Equal(t, "./mocks", config.fOutput)
+	assert.Equal(t, ".", config.fDir)
+	assert.Equal(t, false, config.fRecursive)
+	assert.Equal(t, false, config.fAll)
+	assert.Equal(t, false, config.fIP)
+	assert.Equal(t, false, config.fTO)
+	assert.Equal(t, "camel", config.fCase)
+	assert.Equal(t, "", config.fNote)
+}
+
+func TestParseConfigFlippingValues(t *testing.T) {
+	config := configFromCommandLine("mockery -name hi -print -output output -dir dir -recursive -all -inpkg -testonly -case case -note note")
+	assert.Equal(t, "hi", config.fName)
+	assert.Equal(t, true, config.fPrint)
+	assert.Equal(t, "output", config.fOutput)
+	assert.Equal(t, "dir", config.fDir)
+	assert.Equal(t, true, config.fRecursive)
+	assert.Equal(t, true, config.fAll)
+	assert.Equal(t, true, config.fIP)
+	assert.Equal(t, true, config.fTO)
+	assert.Equal(t, "case", config.fCase)
+	assert.Equal(t, "note", config.fNote)
 }

--- a/cmd/mockery/mockery_test.go
+++ b/cmd/mockery/mockery_test.go
@@ -7,31 +7,6 @@ import (
 	"strings"
 )
 
-func TestUnderscoreCaseName(t *testing.T) {
-	assert.Equal(t, "notify_event", underscoreCaseName("NotifyEvent"))
-	assert.Equal(t, "repository", underscoreCaseName("Repository"))
-	assert.Equal(t, "http_server", underscoreCaseName("HTTPServer"))
-	assert.Equal(t, "awesome_http_server", underscoreCaseName("AwesomeHTTPServer"))
-	assert.Equal(t, "csv", underscoreCaseName("CSV"))
-	assert.Equal(t, "position0_size", underscoreCaseName("Position0Size"))
-}
-
-func TestFilenameBare(t *testing.T) {
-	assert.Equal(t, "name.go", filename("name", Config{fIP: false, fTO: false}))
-}
-
-func TestFilenameMockOnly(t *testing.T) {
-	assert.Equal(t, "mock_name.go", filename("name", Config{fIP: true, fTO: false}))
-}
-
-func TestFilenameMockTest(t *testing.T) {
-	assert.Equal(t, "mock_name_test.go", filename("name", Config{fIP: true, fTO: true}))
-}
-
-func TestFilenameTest(t *testing.T) {
-	assert.Equal(t, "name_test.go", filename("name", Config{fIP: false, fTO: true}))
-}
-
 func configFromCommandLine(str string) Config {
 	return parseConfigFromArgs(strings.Split(str, " "))
 }

--- a/mockery/outputter.go
+++ b/mockery/outputter.go
@@ -1,0 +1,78 @@
+package mockery
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type Cleanup func() error
+
+type OutputStreamProvider interface {
+	GetWriter(iface *Interface, pkg string) (io.Writer, error, Cleanup)
+}
+
+type StdoutStreamProvider struct {
+}
+
+func (this *StdoutStreamProvider) GetWriter(iface *Interface, pkg string) (io.Writer, error, Cleanup) {
+	return os.Stdout, nil, func() error { return nil }
+}
+
+type FileOutputStreamProvider struct {
+	BaseDir   string
+	InPackage bool
+	TestOnly  bool
+	Case      string
+}
+
+func (this *FileOutputStreamProvider) GetWriter(iface *Interface, pkg string) (io.Writer, error, Cleanup) {
+	var path string
+
+	caseName := iface.Name
+	if this.Case == "underscore" {
+		caseName = this.underscoreCaseName(caseName)
+	}
+
+	if this.InPackage {
+		path = filepath.Join(filepath.Dir(iface.Path), this.filename(caseName))
+	} else {
+		path = filepath.Join(this.BaseDir, this.filename(caseName))
+		os.MkdirAll(filepath.Dir(path), 0755)
+		pkg = filepath.Base(filepath.Dir(path))
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err, func() error { return nil }
+	}
+
+	defer f.Close()
+
+	fmt.Printf("Generating mock for: %s\n", iface.Name)
+	return f, nil, func() error {
+		return f.Close()
+	}
+}
+
+func (this *FileOutputStreamProvider) filename(name string) string {
+	if this.InPackage && this.TestOnly {
+		return "mock_" + name + "_test.go"
+	} else if this.InPackage {
+		return "mock_" + name + ".go"
+	} else if this.TestOnly {
+		return name + "_test.go"
+	}
+	return name + ".go"
+}
+
+// shamelessly taken from http://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-camel-caseo
+func (this *FileOutputStreamProvider) underscoreCaseName(caseName string) string {
+	rxp1 := regexp.MustCompile("(.)([A-Z][a-z]+)")
+	s1 := rxp1.ReplaceAllString(caseName, "${1}_${2}")
+	rxp2 := regexp.MustCompile("([a-z0-9])([A-Z])")
+	return strings.ToLower(rxp2.ReplaceAllString(s1, "${1}_${2}"))
+}

--- a/mockery/outputter_test.go
+++ b/mockery/outputter_test.go
@@ -1,0 +1,36 @@
+package mockery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilenameBare(t *testing.T) {
+	out := FileOutputStreamProvider{InPackage: false, TestOnly: false}
+	assert.Equal(t, "name.go", out.filename("name"))
+}
+
+func TestFilenameMockOnly(t *testing.T) {
+	out := FileOutputStreamProvider{InPackage: true, TestOnly: false}
+	assert.Equal(t, "mock_name.go", out.filename("name"))
+}
+
+func TestFilenameMockTest(t *testing.T) {
+	out := FileOutputStreamProvider{InPackage: true, TestOnly: true}
+	assert.Equal(t, "mock_name_test.go", out.filename("name"))
+}
+
+func TestFilenameTest(t *testing.T) {
+	out := FileOutputStreamProvider{InPackage: false, TestOnly: true}
+	assert.Equal(t, "name_test.go", out.filename("name"))
+}
+
+func TestUnderscoreCaseName(t *testing.T) {
+	assert.Equal(t, "notify_event", (&FileOutputStreamProvider{}).underscoreCaseName("NotifyEvent"))
+	assert.Equal(t, "repository", (&FileOutputStreamProvider{}).underscoreCaseName("Repository"))
+	assert.Equal(t, "http_server", (&FileOutputStreamProvider{}).underscoreCaseName("HTTPServer"))
+	assert.Equal(t, "awesome_http_server", (&FileOutputStreamProvider{}).underscoreCaseName("AwesomeHTTPServer"))
+	assert.Equal(t, "csv", (&FileOutputStreamProvider{}).underscoreCaseName("CSV"))
+	assert.Equal(t, "position0_size", (&FileOutputStreamProvider{}).underscoreCaseName("Position0Size"))
+}

--- a/mockery/walker.go
+++ b/mockery/walker.go
@@ -1,0 +1,125 @@
+package mockery
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type Walker struct {
+	BaseDir   string
+	Recursive bool
+	Filter    *regexp.Regexp
+	LimitOne  bool
+}
+
+type WalkerVisitor interface {
+	VisitWalk(*Interface) error
+}
+
+func (this *Walker) Walk(visitor WalkerVisitor) (generated bool) {
+	return this.doWalk(this.BaseDir, visitor)
+}
+
+func (this *Walker) doWalk(dir string, visitor WalkerVisitor) (generated bool) {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), ".") {
+			continue
+		}
+
+		path := filepath.Join(dir, file.Name())
+
+		if file.IsDir() {
+			if this.Recursive {
+				generated = this.doWalk(path, visitor) || generated
+				if generated && this.LimitOne {
+					return
+				}
+			}
+			continue
+		}
+
+		if !strings.HasSuffix(path, ".go") {
+			continue
+		}
+
+		p := NewParser()
+
+		err = p.Parse(path)
+		if err != nil {
+			continue
+		}
+		for _, iface := range p.Interfaces() {
+			if !this.Filter.MatchString(iface.Name) {
+				continue
+			}
+			err := visitor.VisitWalk(iface)
+			if err != nil {
+				fmt.Printf("Error walking %s: %s\n", iface.Name, err)
+				os.Exit(1)
+			}
+			generated = true
+			if this.LimitOne {
+				return
+			}
+		}
+	}
+
+	return
+}
+
+type GeneratorVisitor struct {
+	InPackage bool
+	Note      string
+	Osp       OutputStreamProvider
+}
+
+func (this *GeneratorVisitor) VisitWalk(iface *Interface) error {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Printf("Unable to generated mock for '%s': %s\n", iface.Name, r)
+			return
+		}
+	}()
+
+	var out io.Writer
+
+	pkg := "mocks"
+
+	out, err, closer := this.Osp.GetWriter(iface, pkg)
+	if err != nil {
+		fmt.Printf("Unable to get writer for %s: %s", iface.Name, err)
+		os.Exit(1)
+	}
+	defer closer()
+
+	gen := NewGenerator(iface)
+
+	if this.InPackage {
+		gen.GenerateIPPrologue()
+	} else {
+		gen.GeneratePrologue(pkg)
+	}
+
+	gen.GeneratePrologueNote(this.Note)
+
+	err = gen.Generate()
+	if err != nil {
+		return err
+	}
+
+	err = gen.Write(out)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/mockery/walker_test.go
+++ b/mockery/walker_test.go
@@ -42,7 +42,31 @@ func TestWalkerHere(t *testing.T) {
 		fmt.Println(i)
 	}
 
-	assert.Equal(t, 17, len(gv.Interfaces))
+	assert.Equal(t, 18, len(gv.Interfaces))
+	first := gv.Interfaces[0]
+	assert.Equal(t, "AsyncProducer", first.Name)
+	assert.Equal(t, path.Join(wd, "fixtures/async.go"), first.Path)
+}
+
+func TestWalkerRegexp(t *testing.T) {
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	w := Walker{
+		BaseDir:   wd,
+		Recursive: true,
+		LimitOne:  false,
+		Filter:    regexp.MustCompile(".*AsyncProducer*."),
+	}
+
+	gv := NewGatheringVisitor()
+
+	w.Walk(gv)
+
+	for _, i := range gv.Interfaces {
+		fmt.Println(i)
+	}
+
+	assert.Equal(t, 1, len(gv.Interfaces))
 	first := gv.Interfaces[0]
 	assert.Equal(t, "AsyncProducer", first.Name)
 	assert.Equal(t, path.Join(wd, "fixtures/async.go"), first.Path)

--- a/mockery/walker_test.go
+++ b/mockery/walker_test.go
@@ -1,7 +1,6 @@
 package mockery
 
 import (
-	"fmt"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"path"
@@ -38,10 +37,6 @@ func TestWalkerHere(t *testing.T) {
 
 	w.Walk(gv)
 
-	for _, i := range gv.Interfaces {
-		fmt.Println(i)
-	}
-
 	assert.Equal(t, 18, len(gv.Interfaces))
 	first := gv.Interfaces[0]
 	assert.Equal(t, "AsyncProducer", first.Name)
@@ -61,10 +56,6 @@ func TestWalkerRegexp(t *testing.T) {
 	gv := NewGatheringVisitor()
 
 	w.Walk(gv)
-
-	for _, i := range gv.Interfaces {
-		fmt.Println(i)
-	}
 
 	assert.Equal(t, 1, len(gv.Interfaces))
 	first := gv.Interfaces[0]

--- a/mockery/walker_test.go
+++ b/mockery/walker_test.go
@@ -1,0 +1,11 @@
+package mockery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWalk(t *testing.T) {
+	assert.Equal(t, "true", "true")
+}

--- a/mockery/walker_test.go
+++ b/mockery/walker_test.go
@@ -1,11 +1,49 @@
 package mockery
 
 import (
-	"testing"
-
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"os"
+	"path"
+	"regexp"
+	"testing"
 )
 
-func TestWalk(t *testing.T) {
-	assert.Equal(t, "true", "true")
+type GatheringVisitor struct {
+	Interfaces []*Interface
+}
+
+func (this *GatheringVisitor) VisitWalk(iface *Interface) error {
+	this.Interfaces = append(this.Interfaces, iface)
+	return nil
+}
+
+func NewGatheringVisitor() *GatheringVisitor {
+	return &GatheringVisitor{
+		Interfaces: make([]*Interface, 0, 1024),
+	}
+}
+
+func TestWalkerHere(t *testing.T) {
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	w := Walker{
+		BaseDir:   wd,
+		Recursive: true,
+		LimitOne:  false,
+		Filter:    regexp.MustCompile(".*"),
+	}
+
+	gv := NewGatheringVisitor()
+
+	w.Walk(gv)
+
+	for _, i := range gv.Interfaces {
+		fmt.Println(i)
+	}
+
+	assert.Equal(t, 17, len(gv.Interfaces))
+	first := gv.Interfaces[0]
+	assert.Equal(t, "AsyncProducer", first.Name)
+	assert.Equal(t, path.Join(wd, "fixtures/async.go"), first.Path)
 }


### PR DESCRIPTION
This follows on  #63 and moves the walker and the generator out to its own types. Also adds some unit tests around the walking. This is in support of testing and augmenting the walking logic.