### PR TITLE
use first component of $GOPATH for relative path

### DIFF
--- a/mockery/generator.go
+++ b/mockery/generator.go
@@ -72,7 +72,7 @@ func (g *Generator) mockName() string {
 func (g *Generator) GeneratePrologue(pkg string) {
 	g.printf("package %v\n\n", pkg)
 
-	goPath := os.Getenv("GOPATH")
+	goPath := strings.SplitN(os.Getenv("GOPATH"), string(os.PathListSeparator), 2)[0]
 
 	local, err := filepath.Rel(filepath.Join(goPath, "src"), filepath.Dir(g.iface.Path))
 	if err != nil {

--- a/mockery/generator_test.go
+++ b/mockery/generator_test.go
@@ -3,6 +3,7 @@ package mockery
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -180,7 +181,7 @@ func TestGeneratorPrologue(t *testing.T) {
 
 	gen.GeneratePrologue("mocks")
 
-	goPath := os.Getenv("GOPATH")
+	goPath := strings.SplitN(os.Getenv("GOPATH"), string(os.PathListSeparator), 2)[0]
 	local, err := filepath.Rel(filepath.Join(goPath, "src"), filepath.Dir(iface.Path))
 	assert.NoError(t, err)
 
@@ -205,7 +206,7 @@ func TestGeneratorProloguewithImports(t *testing.T) {
 
 	gen.GeneratePrologue("mocks")
 
-	goPath := os.Getenv("GOPATH")
+	goPath := strings.SplitN(os.Getenv("GOPATH"), string(os.PathListSeparator), 2)[0]
 	local, err := filepath.Rel(filepath.Join(goPath, "src"), filepath.Dir(iface.Path))
 	assert.NoError(t, err)
 


### PR DESCRIPTION
On certain setups it's not uncommon to have multiple entries in $GOPATH.
For example, NixOS provides packaging for Go apps and libraries, and
those libraries get automagically added to $GOPATH (I'm handwaving a
bit, as this commit is too small to talk about the intricacies -- and
wonders -- of Nix & NixOS).
So, let's use specifically the first component of $GOPATH.