### PR TITLE
Skip *_test.go files

### DIFF
--- a/mockery/walker.go
+++ b/mockery/walker.go
@@ -48,7 +48,7 @@ func (this *Walker) doWalk(dir string, visitor WalkerVisitor) (generated bool) {
 			continue
 		}
 
-		if !strings.HasSuffix(path, ".go") {
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			continue
 		}
 


### PR DESCRIPTION
This fixes a problem I was seeing relating to missing imports when using `-all`.

Also, there should not be interfaces in test files, so we do not need to parse them.