### PR TITLE
Move a note in the prologue to top of a file

### DIFF
--- a/mockery/walker.go
+++ b/mockery/walker.go
@@ -111,8 +111,8 @@ func (this *GeneratorVisitor) VisitWalk(iface *Interface) error {
 	defer closer()
 
 	gen := NewGenerator(iface, pkg, this.InPackage)
-	gen.GeneratePrologue(pkg)
 	gen.GeneratePrologueNote(this.Note)
+	gen.GeneratePrologue(pkg)
 
 	err = gen.Generate()
 	if err != nil {


### PR DESCRIPTION
This request moves "notes in the prologue" (by #27) to top of each files.

This can be useful to collapse diffs of generated file in GitHub reviews.

For example: 

```
mockery -all -note "Code generated by mockery. DO NOT EDIT!"
```

Results that generated will look like this

```
// Code generated by mockery. DO NOT EDIT!

package mocks

import "github.com/stretchr/testify/mock"
```

and in GitHub reviews, like this:

![](https://cloud.githubusercontent.com/assets/5582459/20951528/a17b56b0-bc69-11e6-98da-61e9b8621804.png)