### PR TITLE
Fix support for relative paths to mock targets with vendor deps

### DIFF
--- a/mockery/parse.go
+++ b/mockery/parse.go
@@ -25,11 +25,6 @@ func NewParser() *Parser {
 }
 
 func (p *Parser) Parse(path string) error {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return err
-	}
-
 	// To support relative paths to mock targets w/ vendor deps, we need to provide eventual
 	// calls to build.Context.Import with an absolute path. It needs to be absolute because
 	// Import will only find the vendor directory if our target path for parsing is under
@@ -37,7 +32,10 @@ func (p *Parser) Parse(path string) error {
 	//
 	// For example, if our parse target is "./ifaces", Import will check if any "roots" are a
 	// prefix of "ifaces" and decide to skip the vendor search.
-	path = abs
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
 
 	dir := filepath.Dir(path)
 
@@ -69,13 +67,13 @@ func (p *Parser) Parse(path string) error {
 		p.nameToASTFiles[f.Name.String()] = append(p.nameToASTFiles[f.Name.String()], f)
 	}
 
-	p.path = abs
+	p.path = path
 
 	// Type-check a package consisting of this file.
 	// Type information for the imported packages
 	// comes from $GOROOT/pkg/$GOOS_$GOOARCH/fmt.a.
 	for _, files := range p.nameToASTFiles {
-		conf.CreateFromFiles(abs, files...)
+		conf.CreateFromFiles(path, files...)
 	}
 
 	prog, err := conf.Load()


### PR DESCRIPTION
Currently `-dir=./somelib` is not supported if `somelib` interfaces have vendor dependencies.

This PR may address the use cases in #91 and #112.

Explanation:

To support relative paths to mock targets w/ vendor deps, we need to provide eventual calls                                                                                                                                
to `build.Context.Import` with an absolute path. It needs to be absolute because
`Import` will only find the vendor directory if our target path for parsing is under
a "root" (`GOROOT` or a `GOPATH`). Only absolute paths will pass the prefix-based validation.

For example, after `Parse("./somelib")`, `Import` will check if any "roots" are a
prefix of `"somelib"` and decide to skip the vendor search.

It's possible that both the `go/loader` commits referenced/linked in #91 and #112 led to compatibility
issues with the [migration to go/loader](https://github.com/vektra/mockery/commit/79510c38075c14feb801e9ce7e1eafe7792de80e). I think the current incompatibility, for the `-dir=./somelib` use case, is with `go/build` behavior that [landed in Go 1.6](https://github.com/golang/go/commit/0c428a56176353d52170f318e998f342b08dacd2) which made absolute paths required to trigger vendor search AFAICT.