### PR TITLE
Fix generated import paths on Windows

### DIFF
--- a/mockery/generator.go
+++ b/mockery/generator.go
@@ -116,7 +116,10 @@ func (g *Generator) getNonConflictingName(path, name string) string {
 	if !g.importNameExists(name) {
 		return name
 	}
-	directories := strings.Split(path, string(filepath.Separator))
+
+	// The path will always contain '/' because it is enforced in getLocalizedPath
+	// regardless of OS.
+	directories := strings.Split(path, "/")
 
 	cleanedDirectories := make([]string, 0, len(directories))
 	for _, directory := range directories {
@@ -191,6 +194,9 @@ func (g *Generator) getLocalizedPath(path string) string {
 	} else if filepath.IsAbs(path) {
 		toReturn = calculateImport(g.packageRoots, path)
 	}
+
+	// Enforce '/' slashes for import paths in every OS.
+	toReturn = filepath.ToSlash(toReturn)
 
 	g.localizationCache[path] = toReturn
 	return toReturn

--- a/mockery/generator_test.go
+++ b/mockery/generator_test.go
@@ -66,7 +66,9 @@ func (s *GeneratorSuite) checkPrologueGeneration(
 func (s *GeneratorSuite) getInterfaceRelPath(iface *Interface) string {
 	local, err := filepath.Rel(getGoPathSrc(), filepath.Dir(iface.Path))
 	s.NoError(err, "No errors with relative path generation.")
-	return local
+
+	// Align w/ Generator.getLocalizedPath and enforce '/' slashes for import paths in every OS.
+	return filepath.ToSlash(local)
 }
 
 func (s *GeneratorSuite) TestCalculateImport() {

--- a/mockery/walker_test.go
+++ b/mockery/walker_test.go
@@ -2,7 +2,7 @@ package mockery
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -45,7 +45,7 @@ func TestWalkerHere(t *testing.T) {
 	assert.True(t, len(gv.Interfaces) > 10)
 	first := gv.Interfaces[0]
 	assert.Equal(t, "AsyncProducer", first.Name)
-	assert.Equal(t, path.Join(wd, "fixtures/async.go"), first.Path)
+	assert.Equal(t, filepath.Join(wd, "fixtures", "async.go"), first.Path)
 }
 
 func TestWalkerRegexp(t *testing.T) {
@@ -69,5 +69,5 @@ func TestWalkerRegexp(t *testing.T) {
 	assert.True(t, len(gv.Interfaces) >= 1)
 	first := gv.Interfaces[0]
 	assert.Equal(t, "AsyncProducer", first.Name)
-	assert.Equal(t, path.Join(wd, "fixtures/async.go"), first.Path)
+	assert.Equal(t, filepath.Join(wd, "fixtures", "async.go"), first.Path)
 }


### PR DESCRIPTION
These patches get the tests passing on Windows based on experiments with [AppVeyor CI](https://ci.appveyor.com/project/codeactual/mockery/build/9/job/nut4717w4giw1txp).

The issue was "\\" separators in generated import paths, as guessed in #14.

I haven't been able to reproduce #14 and #119 yet , so I'm not sure if this patch resolves either of them. But it should get the generator closer to compatible. 