### PR TITLE
Adding mockery.prof to git ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 mocks
+mockery.prof


### PR DESCRIPTION
mockery.prof is a file that is generated by the integration target adding that allows the cpu profile of the test to be examined.

Should be added to git ignore in order to avoid checking it in