### PR TITLE
Allow generator fixtures to use formatted source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=bash
 
-all: clean fmt test install integration
+all: clean fmt test fixture install integration
 
 clean:
 	rm -rf mocks
@@ -10,6 +10,9 @@ fmt:
 
 test:
 	go test ./...
+
+fixture:
+	mockery -print -dir mockery/fixtures -name RequesterVariadic > mockery/fixtures/mocks/requester_variadic.go
 
 install:
 	go install ./...

--- a/mockery/fixtures/mocks/requester_variadic.go
+++ b/mockery/fixtures/mocks/requester_variadic.go
@@ -27,6 +27,7 @@ func (_m *RequesterVariadic) Get(values ...string) bool {
 
 	return r0
 }
+
 // MultiWriteToFile provides a mock function with given fields: filename, w
 func (_m *RequesterVariadic) MultiWriteToFile(filename string, w ...io.Writer) string {
 	_va := make([]interface{}, len(w))
@@ -47,6 +48,7 @@ func (_m *RequesterVariadic) MultiWriteToFile(filename string, w ...io.Writer) s
 
 	return r0
 }
+
 // OneInterface provides a mock function with given fields: a
 func (_m *RequesterVariadic) OneInterface(a ...interface{}) bool {
 	var _ca []interface{}
@@ -62,6 +64,7 @@ func (_m *RequesterVariadic) OneInterface(a ...interface{}) bool {
 
 	return r0
 }
+
 // Sprintf provides a mock function with given fields: format, a
 func (_m *RequesterVariadic) Sprintf(format string, a ...interface{}) string {
 	var _ca []interface{}

--- a/mockery/generator_test.go
+++ b/mockery/generator_test.go
@@ -53,11 +53,11 @@ func (s *GeneratorSuite) checkGeneration(
 	generator := s.getGenerator(filepath, interfaceName, inPackage)
 	s.NoError(generator.Generate(), "The generator ran without errors.")
 
-	// Mirror the formatting done by normally done by golang.org/x/tools/imports in Generator.Write
+	// Mirror the formatting done by normally done by golang.org/x/tools/imports in Generator.Write.
 	//
 	// While we could possibly reuse Generator.Write here in addition to Generator.Generate,
 	// it would require changing Write's signature to accept custom options, specifically to
-	// allow the fragmeents already used in test cases. It's assumed that this approximation,
+	// allow the fragments in preexisting cases. It's assumed that this approximation,
 	// just formatting the source, is sufficient for the needs of the current test styles.
 	var actual []byte
 	actual, fmtErr := format.Source(generator.buf.Bytes())

--- a/mockery/generator_test.go
+++ b/mockery/generator_test.go
@@ -51,8 +51,13 @@ func (s *GeneratorSuite) checkGeneration(
 ) *Generator {
 	generator := s.getGenerator(filepath, interfaceName, inPackage)
 	s.NoError(generator.Generate(), "The generator ran without errors.")
+
+	// Compare lines for easier debugging via testify's slice diff output
+	expectedLines := strings.Split(expected, "\n")
+	actualLines := strings.Split(generator.buf.String(), "\n")
+
 	s.Equal(
-		expected, generator.buf.String(),
+		expectedLines, actualLines,
 		"The generator produced the expected output.",
 	)
 	return generator


### PR DESCRIPTION
This should fix #137 and allow fixtures to always be formatted, which should be a requirement anyway to mirror the behavior to `Generator.Write`.