### PR TITLE
Add build tag support

### DIFF
--- a/mockery/fixtures/buildtag/comment/darwin_iface.go
+++ b/mockery/fixtures/buildtag/comment/darwin_iface.go
@@ -1,0 +1,7 @@
+// +build darwin
+
+package comment
+
+type IfaceWithBuildTagInComment interface {
+	Sprintf(format string, a ...interface{}) string
+}

--- a/mockery/fixtures/buildtag/comment/freebsd_iface.go
+++ b/mockery/fixtures/buildtag/comment/freebsd_iface.go
@@ -1,0 +1,7 @@
+// +build freebsd
+
+package comment
+
+type IfaceWithBuildTagInComment interface {
+	Sprintf(format string, a ...interface{}) string
+}

--- a/mockery/fixtures/buildtag/comment/linux_iface.go
+++ b/mockery/fixtures/buildtag/comment/linux_iface.go
@@ -1,0 +1,7 @@
+// +build linux
+
+package comment
+
+type IfaceWithBuildTagInComment interface {
+	Sprintf(format string, a ...interface{}) string
+}

--- a/mockery/fixtures/buildtag/comment/windows_iface.go
+++ b/mockery/fixtures/buildtag/comment/windows_iface.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package comment
+
+type IfaceWithBuildTagInComment interface {
+	Sprintf(format string, a ...interface{}) string
+}

--- a/mockery/fixtures/buildtag/filename/iface_darwin.go
+++ b/mockery/fixtures/buildtag/filename/iface_darwin.go
@@ -1,0 +1,5 @@
+package filename
+
+type IfaceWithBuildTagInFilename interface {
+	Sprintf(format string, a ...interface{}) string
+}

--- a/mockery/fixtures/buildtag/filename/iface_freebsd.go
+++ b/mockery/fixtures/buildtag/filename/iface_freebsd.go
@@ -1,0 +1,5 @@
+package filename
+
+type IfaceWithBuildTagInFilename interface {
+	Sprintf(format string, a ...interface{}) string
+}

--- a/mockery/fixtures/buildtag/filename/iface_linux.go
+++ b/mockery/fixtures/buildtag/filename/iface_linux.go
@@ -1,0 +1,5 @@
+package filename
+
+type IfaceWithBuildTagInFilename interface {
+	Sprintf(format string, a ...interface{}) string
+}

--- a/mockery/fixtures/buildtag/filename/iface_windows.go
+++ b/mockery/fixtures/buildtag/filename/iface_windows.go
@@ -1,0 +1,5 @@
+package filename
+
+type IfaceWithBuildTagInFilename interface {
+	Sprintf(format string, a ...interface{}) string
+}

--- a/mockery/mockery_test.go
+++ b/mockery/mockery_test.go
@@ -1,0 +1,24 @@
+package mockery
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var fixturePath string
+
+func init() {
+	dir, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	fixturePath = filepath.Join(dir, "fixtures")
+}
+
+// getFixturePath returns an absolute path to a fixture sub-directory or file.
+//
+// getFixturePath("src.go") returns "/path/to/fixtures/src.go"
+// getFixturePath("a", "b", "c", "src.go") returns "/path/to/fixtures/a/b/c/src.go"
+func getFixturePath(subdirOrBasename ...string) string {
+	return filepath.Join(append([]string{fixturePath}, subdirOrBasename...)...)
+}

--- a/mockery/parse_test.go
+++ b/mockery/parse_test.go
@@ -41,3 +41,47 @@ func noTestFileInterfaces(t *testing.T) {
 	assert.Equal(t, 1, len(nodes))
 	assert.Equal(t, "Requester", nodes[0].Name)
 }
+
+func TestBuildTagInFilename(t *testing.T) {
+	parser := NewParser()
+
+	// Include the major OS values found on https://golang.org/dl/ so we're likely to match
+	// anywhere the test is executed.
+	err := parser.Parse(getFixturePath("buildtag", "filename", "iface_windows.go"))
+	assert.NoError(t, err)
+	err = parser.Parse(getFixturePath("buildtag", "filename", "iface_linux.go"))
+	assert.NoError(t, err)
+	err = parser.Parse(getFixturePath("buildtag", "filename", "iface_darwin.go"))
+	assert.NoError(t, err)
+	err = parser.Parse(getFixturePath("buildtag", "filename", "iface_freebsd.go"))
+	assert.NoError(t, err)
+
+	err = parser.Load()
+	assert.NoError(t, err) // Expect "redeclared in this block" if tags aren't respected
+
+	nodes := parser.Interfaces()
+	assert.Equal(t, 1, len(nodes))
+	assert.Equal(t, "IfaceWithBuildTagInFilename", nodes[0].Name)
+}
+
+func TestBuildTagInComment(t *testing.T) {
+	parser := NewParser()
+
+	// Include the major OS values found on https://golang.org/dl/ so we're likely to match
+	// anywhere the test is executed.
+	err := parser.Parse(getFixturePath("buildtag", "comment", "windows_iface.go"))
+	assert.NoError(t, err)
+	err = parser.Parse(getFixturePath("buildtag", "comment", "linux_iface.go"))
+	assert.NoError(t, err)
+	err = parser.Parse(getFixturePath("buildtag", "comment", "darwin_iface.go"))
+	assert.NoError(t, err)
+	err = parser.Parse(getFixturePath("buildtag", "comment", "freebsd_iface.go"))
+	assert.NoError(t, err)
+
+	err = parser.Load()
+	assert.NoError(t, err) // Expect "redeclared in this block" if tags aren't respected
+
+	nodes := parser.Interfaces()
+	assert.Equal(t, 1, len(nodes))
+	assert.Equal(t, "IfaceWithBuildTagInComment", nodes[0].Name)
+}

--- a/mockery/parse_test.go
+++ b/mockery/parse_test.go
@@ -1,27 +1,17 @@
 package mockery
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-var fixturePath string
 var testFile string
 var testFile2 string
 
 func init() {
-	dir, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-
-	fixturePath = filepath.Join(dir, "fixtures")
-
-	testFile = filepath.Join(dir, "fixtures", "requester.go")
-	testFile2 = filepath.Join(dir, "fixtures", "requester2.go")
+	testFile = getFixturePath("requester.go")
+	testFile2 = getFixturePath("requester2.go")
 }
 
 func TestFileParse(t *testing.T) {

--- a/mockery/walker_test.go
+++ b/mockery/walker_test.go
@@ -2,7 +2,6 @@ package mockery
 
 import (
 	"os"
-	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -45,7 +44,7 @@ func TestWalkerHere(t *testing.T) {
 	assert.True(t, len(gv.Interfaces) > 10)
 	first := gv.Interfaces[0]
 	assert.Equal(t, "AsyncProducer", first.Name)
-	assert.Equal(t, filepath.Join(wd, "fixtures", "async.go"), first.Path)
+	assert.Equal(t, getFixturePath("async.go"), first.Path)
 }
 
 func TestWalkerRegexp(t *testing.T) {
@@ -69,5 +68,5 @@ func TestWalkerRegexp(t *testing.T) {
 	assert.True(t, len(gv.Interfaces) >= 1)
 	first := gv.Interfaces[0]
 	assert.Equal(t, "AsyncProducer", first.Name)
-	assert.Equal(t, filepath.Join(wd, "fixtures", "async.go"), first.Path)
+	assert.Equal(t, getFixturePath("async.go"), first.Path)
 }


### PR DESCRIPTION
Should resolve #109 by reusing [go/build.Context.MatchFile](https://golang.org/pkg/go/build/#Context.MatchFile) to know if we should include a given file.

([tests results on Windows](https://ci.appveyor.com/project/codeactual/mockery/build/18/job/ewf16gyi76uthee1))