### PR TITLE
Evaluate symlinks while walking

### DIFF
--- a/mockery/parse.go
+++ b/mockery/parse.go
@@ -49,6 +49,11 @@ func (p *Parser) Parse(path string) error {
 		return err
 	}
 
+	path, err = filepath.EvalSymlinks(path)
+	if err != nil {
+		return err
+	}
+
 	dir := filepath.Dir(path)
 
 	files, err := ioutil.ReadDir(dir)


### PR DESCRIPTION
The issue I'm trying to solve in the PR is about symlink in go workspace.

My working project in real go workspace is 

```
/Users/abnerchen/Projects/go/src/github.com/<my-org>/<my-repo>
``` 

and I made a symlink to it which is 

```
/Users/abnerchen/Projects/<my-repo>
```

Every time I generate the mock interface by mockery: 

```shell
[~/Projects/<my-repo>/helper]# mockery -name=Helper
```

will insert the import path, `import helper "/Users/abnerchen/Projects/<my-repo>/helper/"`, instead of `import helper "github.com/<my-org>/<my-repo>/helper"` into the generated mock file.

And if I switch my work directory to `/Users/abnerchen/Projects/go/src/github.com/<my-org>/<my-repo>` and use mockery, it works as expected.

So, I think it will be great if the parser in mockery can evaluate symlinks.

Please let me know if there is any concern about this change.
Thanks!