### PR TITLE
Print mock.go to stderr on imports.Process error

### DIFF
--- a/mockery/generator.go
+++ b/mockery/generator.go
@@ -631,6 +631,8 @@ func (g *Generator) Write(w io.Writer) error {
 
 	res, err := imports.Process("mock.go", theBytes, opt)
 	if err != nil {
+		line := "--------------------------------------------------------------------------------------------"
+		fmt.Fprintf(os.Stderr, "Between the lines is the file (mock.go) mockery generated in-memory but detected as invalid:\n%s\n%s\n%s\n", line, g.buf.String(), line)
 		return err
 	}
 


### PR DESCRIPTION
Let people know what "mock.go" is when it appears in error messages, and provide the source so it can be debugged or pasted into bug reports.