### PR TITLE
Just ignore files that can't be parsed

### DIFF
--- a/mockery/walker.go
+++ b/mockery/walker.go
@@ -79,7 +79,7 @@ func (this *Walker) doWalk(p *Parser, dir string, visitor WalkerVisitor) (genera
 		err = p.Parse(path)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Error parsing file: ", err)
-			return
+			continue
 		}
 	}
 


### PR DESCRIPTION
The problem is, if I try to use mockery with custom filename in same package (workdir) like this:

```bash
$ mockery -name Storage -inpkg -print > mock_example_storage.go
```

I have got an error:
> mock_storage.go:1:1: expected 'package', found 'EOF'

and my output file `mock_example_storage.go` will be empty. Because mockery stopping after parse error.

But if I remove extension, it works fine. 
But of course I need to add some ugly hack to rename file in `.go`:

```bash
$ mockery -name Storage -inpkg -print > mock_example_storage ; mv mock_example_storage mock_example_storage.go
```

So my proposal is just ignore files, which `mockery` can't parse. 
I think tool shouldn't be stopped if it can't parse one `*.go` file.