### PR TITLE
Revert "Evaluate symlinks while walking"

### DIFF
--- a/mockery/parse.go
+++ b/mockery/parse.go
@@ -58,11 +58,6 @@ func (p *Parser) Parse(path string) error {
 		return err
 	}
 
-	path, err = filepath.EvalSymlinks(path)
-	if err != nil {
-		return err
-	}
-
 	dir := filepath.Dir(path)
 
 	files, err := ioutil.ReadDir(dir)


### PR DESCRIPTION
This reverts commit a8a65c4f5712175b905424cf6331eab72db21c93.

Evaluating symlinks can cause `build.Context.Import` to not find imports from vendor directory, because `Import` only finds the vendor directory if the target path is under GOPATH or GOROOT, as mentioned [here](https://github.com/vektra/mockery/blob/master/mockery/parse.go#L51).

For example:

John has a project in `/Users/John/myproject`, to which he sets a symlink `/Users/John/go/src/myproject`, and his GOPATH is `/Users/John/go`. 

When he tries to generate mocks for interfaces defined in `/Users/John/go/src/myproject/foo.go`, Mockery evaluates the path to `/Users/John/myproject/foo.go`, which is no longer lexically a subdirectory of his GOPATH, so `Import` will not find import from the vendor directory.

Regarding the issue reported in https://github.com/vektra/mockery/pull/147, I was not able to reproduce with go1.8 and go1.9.