### PR TITLE
Support conventional "snake" as a case argument value

### DIFF
--- a/cmd/mockery/mockery.go
+++ b/cmd/mockery/mockery.go
@@ -128,7 +128,7 @@ func parseConfigFromArgs(args []string) Config {
 	flagSet.BoolVar(&config.fAll, "all", false, "generates mocks for all found interfaces in all sub-directories")
 	flagSet.BoolVar(&config.fIP, "inpkg", false, "generate a mock that goes inside the original package")
 	flagSet.BoolVar(&config.fTO, "testonly", false, "generate a mock in a _test.go file")
-	flagSet.StringVar(&config.fCase, "case", "camel", "name the mocked file using casing convention")
+	flagSet.StringVar(&config.fCase, "case", "camel", "name the mocked file using casing convention [camel, snake, underscore]")
 	flagSet.StringVar(&config.fNote, "note", "", "comment to insert into prologue of each generated file")
 	flagSet.StringVar(&config.fProfile, "cpuprofile", "", "write cpu profile to file")
 	flagSet.BoolVar(&config.fVersion, "version", false, "prints the installed version of mockery")

--- a/mockery/outputter.go
+++ b/mockery/outputter.go
@@ -33,7 +33,7 @@ func (this *FileOutputStreamProvider) GetWriter(iface *Interface, pkg string) (i
 	var path string
 
 	caseName := iface.Name
-	if this.Case == "underscore" {
+	if this.Case == "underscore" || this.Case == "snake" {
 		caseName = this.underscoreCaseName(caseName)
 	}
 


### PR DESCRIPTION
I've been trying to use `mockery` for one of my projects and as a first time user found it counter-intuitive that it uses `underscore` as a case name instead of a conventional `snake`.

My bad, I didn't read the `README` first and was trying to use it guided by the help message provided by `mockery --help` 😃Though I believe it supporting both case names would make its use more intuitive and user-friendly.