### PR TITLE
Fix regression with -inpkg

### DIFF
--- a/mockery/generator_test.go
+++ b/mockery/generator_test.go
@@ -948,7 +948,7 @@ func (_m *Example) B(_a0 string) fixtureshttp.MyStruct {
 
 func (s *GeneratorSuite) TestGeneratorWithImportSameAsLocalPackageInpkgNoCycle() {
 	iface := s.getInterfaceFromFile("imports_same_as_package.go", "ImportsSameAsPackage")
-	pkg := iface.Path
+	pkg := iface.QualifiedName
 	gen := NewGenerator(iface, pkg, true)
 	gen.GeneratePrologue(pkg)
 	s.NotContains(gen.buf.String(), `import test "github.com/vektra/mockery/mockery/fixtures/test"`)
@@ -1007,7 +1007,7 @@ func (s *GeneratorSuite) TestPrologueWithImportSameAsLocalPackage() {
 	)
 	expected := `package mocks
 
-import fixtures "` + generator.iface.Path + `"
+import fixtures "` + generator.iface.QualifiedName + `"
 import mock "github.com/stretchr/testify/mock"
 import test "github.com/vektra/mockery/mockery/fixtures/test"
 

--- a/mockery/parse.go
+++ b/mockery/parse.go
@@ -167,13 +167,13 @@ func (p *Parser) Find(name string) (*Interface, error) {
 }
 
 type Interface struct {
-	Name      string
-	Path      string
-	FileName  string
-	File      *ast.File
-	Pkg       *types.Package
-	Type      *types.Interface
-	NamedType *types.Named
+	Name          string
+	QualifiedName string
+	FileName      string
+	File          *ast.File
+	Pkg           *types.Package
+	Type          *types.Interface
+	NamedType     *types.Named
 }
 
 type sortableIFaceList []*Interface
@@ -231,13 +231,13 @@ func (p *Parser) packageInterfaces(
 		}
 
 		elem := &Interface{
-			Name:      name,
-			Pkg:       pkg,
-			Path:      pkg.Path(),
-			FileName:  fileName,
-			Type:      iface.Complete(),
-			NamedType: typ,
-			File:      file,
+			Name:          name,
+			Pkg:           pkg,
+			QualifiedName: pkg.Path(),
+			FileName:      fileName,
+			Type:          iface.Complete(),
+			NamedType:     typ,
+			File:          file,
 		}
 
 		ifaces = append(ifaces, elem)

--- a/mockery/walker.go
+++ b/mockery/walker.go
@@ -107,12 +107,12 @@ func (this *GeneratorVisitor) VisitWalk(iface *Interface) error {
 	var pkg string
 
 	if this.InPackage {
-		pkg = iface.Path
+		pkg = filepath.Dir(iface.FileName)
 	} else {
 		pkg = this.PackageName
 	}
 
-	out, err, closer := this.Osp.GetWriter(iface, pkg)
+	out, err, closer := this.Osp.GetWriter(iface)
 	if err != nil {
 		fmt.Printf("Unable to get writer for %s: %s", iface.Name, err)
 		os.Exit(1)

--- a/mockery/walker_test.go
+++ b/mockery/walker_test.go
@@ -45,7 +45,7 @@ func TestWalkerHere(t *testing.T) {
 	first := gv.Interfaces[0]
 	assert.Equal(t, "A", first.Name)
 	assert.Equal(t, getFixturePath("struct_value.go"), first.FileName)
-	assert.Equal(t, "github.com/vektra/mockery/mockery/fixtures", first.Path)
+	assert.Equal(t, "github.com/vektra/mockery/mockery/fixtures", first.QualifiedName)
 }
 
 func TestWalkerRegexp(t *testing.T) {
@@ -70,5 +70,5 @@ func TestWalkerRegexp(t *testing.T) {
 	first := gv.Interfaces[0]
 	assert.Equal(t, "AsyncProducer", first.Name)
 	assert.Equal(t, getFixturePath("async.go"), first.FileName)
-	assert.Equal(t, "github.com/vektra/mockery/mockery/fixtures", first.Path)
+	assert.Equal(t, "github.com/vektra/mockery/mockery/fixtures", first.QualifiedName)
 }


### PR DESCRIPTION
Fixes regression (#220) in 0ecc4a91a394dcd6de2535c8262674f8b14767cb where `-inpkg` would get the wrong path.

Also cleans up some unused arguments and missing error handling in the same area of code. Renames `Interface` structs's `Path` to `QualifiedName` to avoid future confusion; with `go/packages`, this is not the file path, but the fully qualified package name.