### PR TITLE
reduce the number of parsing

### DIFF
--- a/mockery/parse.go
+++ b/mockery/parse.go
@@ -5,6 +5,7 @@ import (
 	"go/ast"
 	"go/types"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -54,11 +55,22 @@ func (p *Parser) Parse(path string) error {
 		return err
 	}
 
-	dir := filepath.Dir(path)
-
-	files, err := ioutil.ReadDir(dir)
+	fileInfo, err := os.Stat(path)
 	if err != nil {
 		return err
+	}
+
+	var files []os.FileInfo
+	var dir string
+	if fileInfo.IsDir() {
+		dir = path
+		files, err = ioutil.ReadDir(path)
+		if err != nil {
+			return err
+		}
+	} else {
+		dir = filepath.Dir(path)
+		files = []os.FileInfo{fileInfo}
 	}
 
 	for _, fi := range files {


### PR DESCRIPTION
In [Walker.doWalk](https://github.com/vektra/mockery/blob/e78b021dcbb558a8e7ac1fc5bc757ad7c277bb81/mockery/walker.go#L80), it calls `Parser.parse` for each files in the directory. In [Parser.parse](https://github.com/vektra/mockery/blob/e78b021dcbb558a8e7ac1fc5bc757ad7c277bb81/mockery/parse.go#L59), it takes the directory of the given file, and calls `packages.Load` for all files in the directory again. If there are 10 files in the directory, mockery will eventually call `packages.Load` for 100 times!

This PR reduce the number of calls to `packages.Load` to once per file