### PR TITLE
Fix CI - pin deployment to only one version of Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,4 @@ deploy:
     on:
         tags: true
         condition: $TRAVIS_OS_NAME = linux
+        go: 1.14.x


### PR DESCRIPTION
@LandonTClipp This should fix the race to deploy, but still allow the tests to run on other Go versions.