### PR TITLE
Add support for releasing an offical docker image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,3 +31,20 @@ snapshot:
     name_template: "{{ .Tag }}-next"
 changelog:
     sort: asc
+dockers:
+  - goos: linux
+    goarch: amd64
+    binaries:
+      - mockery
+    image_templates:
+      - 'vektra/mockery:{{ .Tag }}'
+      - 'vektra/mockery:v{{ .Major }}'
+      - 'vektra/mockery:v{{ .Major }}.{{ .Minor }}'
+      - 'vektra/mockery:latest'
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,12 @@ git:
 script: 
   - go test -v -cover ./...
 
+services:
+  - docker
+
+after_success:
+  - test -n "$TRAVIS_TAG" && docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
 deploy:
   - provider: script
     skip_cleanup: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+COPY mockery /
+
+ENTRYPOINT ["/mockery"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM golang:1.14-alpine
 
 COPY mockery /
 


### PR DESCRIPTION
This adds a docker image plus the relevant docker goreleaser/travisci configuration.

To test locally run:
```zsh
goreleaser --snapshot --skip-publish --rm-dist
docker run vektra/mockery --version
```

To test more than just the version you will need to mount your volume:
```zsh
docker run -v "$PWD":/src -w /src vektra/mockery -all
```

**Note**: I originally used a `Scratch` base image, which puts the image around 6MB... but mockery makes use of the `go` command (`go list` etc), so I need to use an image with Go installed. This bumped the image to 375MB!! It's not a major problem as most people will have the Golang base imaged cached, but this could slow down peoples CI for downloading a larger image. 
2 future improvements would be to remove the need for executing `go` commands and installing `Go` onto the scratch image rather than using alpine.

@LandonTClipp We will need to add the secrets for travis: `DOCKER_USERNAME` and `DOCKER_PASSWORD`

I have presumed that there is/would be a docker repo for user `vektra`? We can change if needed.

I have not updated the README, as I think it would be best to get this CI pipeline confirmed working then update to suggest docker. I would recommend that for CI people use the docker version.

Closes #180