### PR TITLE
Add a homebrew deployment

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,3 +48,12 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
+brews:
+  - homepage: https://github.com/vektra/mockery
+    description: "A mock code autogenerator for Go"
+    github:
+        owner: vektra
+        name: homebrew-tap
+    folder: Formula
+    test: |
+        system "#{bin}mockery --version"


### PR DESCRIPTION
This will deploy each release to a homebrew tap. This will allow developers to use `brew` to install and update the mockery binary. This works for both mac and linux. Eg:
```
brew install vektra/tap/mockery
brew upgrade mockery
```
@LandonTClipp This deployment will require that travisCI has access to the repo: `github.com/vektra/homebrew-tap`; this repo will also need creating.