### PR TITLE
add source package support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 mocks
 mockery.prof
 dist
+.idea

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,4 @@ install:
 	go install ./...
 
 integration:
-	rm -rf mocks
-	${GOPATH}/bin/mockery -all -recursive -cpuprofile="mockery.prof" -dir="mockery/fixtures"
-	if [ ! -d "mocks" ]; then \
-		echo "No Mock Dir Created"; \
-		exit 1; \
-	fi
-	if [ ! -f "mocks/AsyncProducer.go" ]; then \
-		echo "AsyncProducer.go not created"; \
-		echo 1; \
-	fi
+	./hack/run-e2e.sh

--- a/cmd/mockery/mockery_test.go
+++ b/cmd/mockery/mockery_test.go
@@ -25,10 +25,11 @@ func TestParseConfigDefaults(t *testing.T) {
 	assert.Equal(t, "", config.fNote)
 	assert.Equal(t, "", config.fFileName)
 	assert.Equal(t, "", config.fStructName)
+	assert.Equal(t, "", config.fSrcPkg)
 }
 
 func TestParseConfigFlippingValues(t *testing.T) {
-	config := configFromCommandLine("mockery -name hi -print -output output -dir dir -recursive -all -inpkg -testonly -case case -note note -structname structname -filename filename")
+	config := configFromCommandLine("mockery -name hi -print -output output -dir dir -recursive -all -inpkg -testonly -case case -note note -structname structname -filename filename -srcpkg github.com/vektra/mockery")
 	assert.Equal(t, "hi", config.fName)
 	assert.Equal(t, true, config.fPrint)
 	assert.Equal(t, "output", config.fOutput)
@@ -41,4 +42,5 @@ func TestParseConfigFlippingValues(t *testing.T) {
 	assert.Equal(t, "note", config.fNote)
 	assert.Equal(t, "filename", config.fFileName)
 	assert.Equal(t, "structname", config.fStructName)
+	assert.Equal(t, "github.com/vektra/mockery", config.fSrcPkg)
 }

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+cd $ROOT
+
+reset() {
+  rm -rf mocks
+}
+
+verify() {
+  if [ ! -d "mocks" ]; then \
+    echo "No Mock Dir Created"; \
+    exit 1; \
+  fi
+  if [ ! -f "mocks/AsyncProducer.go" ]; then \
+    echo "AsyncProducer.go not created"; \
+    echo 1; \
+  fi
+}
+
+trap reset exit
+
+reset
+${GOPATH}/bin/mockery -all -recursive -cpuprofile="mockery.prof" -dir="mockery/fixtures"
+verify
+
+reset
+${GOPATH}/bin/mockery -all -recursive -cpuprofile="mockery.prof" -srcpkg github.com/vektra/mockery/mockery/fixtures
+verify


### PR DESCRIPTION
Signed-off-by: Vincent Huang <vh7157@gmail.com>

## Background

There's a usecase we want to generate mock for external package, there's one solution in community https://github.com/vektra/mockery/issues/210#issuecomment-485026348, but it's not clean to specify another alias interface into my codebase. The other solution is using `-dir` like in this https://github.com/vektra/mockery/issues/210#issuecomment-521112586 but it requires some knowledge to use it right, like it's different under go module and `$GOPATH`.

With this change, we can generate an external package mock anywhere (with go.mod or under $GOPATH) with
```
$ mockery -srcpkg github.com/aws/aws-sdk-go/service/s3 -all
```

## Changes
* add flag `srcpkg`
* import `srcpkg`, read directory and set `BaseDir` to it

## Test
- [x] manually verified on local
- [x] add integration tests
- [x] add unit tests