### PR TITLE
fix for argument type ...map[string]interface{}

### DIFF
--- a/mockery/generator.go
+++ b/mockery/generator.go
@@ -608,7 +608,7 @@ func (g *Generator) generateCalled(list *paramList, formattedParamNames string) 
 
 	var variadicArgsName string
 	variadicName := list.Names[namesLen-1]
-	variadicIface := strings.Contains(list.Types[namesLen-1], "interface{}")
+	variadicIface := strings.Contains(list.Types[namesLen-1], "interface{}") && !strings.Contains(list.Types[namesLen-1], "map")
 
 	if variadicIface {
 		// Variadic is already of the interface{} type, so we don't need special handling.


### PR DESCRIPTION
For the following function argument, the generator produces invalid code
```
Foo(arg1 ...map[string]interface{})
```

Whereas, it works fine for
```
Foo(arg1 ...Msi)
```

Reason: I think on Line #611 the type is checked to include `interface{}` which clearly is not enough.
So, the proposed fix is intended to be a safe workaround until this is looked over in depth.