### PR TITLE
Removing old golang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ env:
   - GO111MODULE=on CGO_ENABLED=0
 
 go:
-  - 1.11.x
-  - 1.12.x
-  - 1.13.x
   - 1.14.x
   - tip
 


### PR DESCRIPTION
We're removing old golang versions from parameterized tests because we
don't really care about the mockery code itself being compatible with
old versions of golang.