### PR TITLE
Adding dry run option

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -199,6 +199,7 @@ func (r *RootApp) Run() error {
 		osp = &pkg.StdoutStreamProvider{}
 	} else {
 		osp = &pkg.FileOutputStreamProvider{
+			Config:                    r.Config,
 			BaseDir:                   r.Config.Output,
 			InPackage:                 r.Config.InPackage,
 			TestOnly:                  r.Config.TestOnly,
@@ -234,6 +235,7 @@ func (r *RootApp) Run() error {
 	}
 
 	visitor := &pkg.GeneratorVisitor{
+		Config:      r.Config,
 		InPackage:   r.Config.InPackage,
 		Note:        r.Config.Note,
 		Osp:         osp,
@@ -242,6 +244,7 @@ func (r *RootApp) Run() error {
 	}
 
 	walker := pkg.Walker{
+		Config:    r.Config,
 		BaseDir:   baseDir,
 		Recursive: recursive,
 		Filter:    filter,

--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog"
+	"github.com/vektra/mockery/pkg/config"
 	"github.com/vektra/mockery/pkg/logging"
 )
 
@@ -26,6 +27,7 @@ func (this *StdoutStreamProvider) GetWriter(ctx context.Context, iface *Interfac
 }
 
 type FileOutputStreamProvider struct {
+	Config                    config.Config
 	BaseDir                   string
 	InPackage                 bool
 	TestOnly                  bool
@@ -70,6 +72,7 @@ func (this *FileOutputStreamProvider) GetWriter(ctx context.Context, iface *Inte
 	log = log.With().Str(logging.LogKeyPath, path).Logger()
 	ctx = log.WithContext(ctx)
 
+	log.Debug().Msgf("creating writer to file")
 	f, err := os.Create(path)
 	if err != nil {
 		return nil, err, func() error { return nil }

--- a/pkg/walker.go
+++ b/pkg/walker.go
@@ -152,9 +152,12 @@ func (this *GeneratorVisitor) VisitWalk(ctx context.Context, iface *Interface) e
 	}
 
 	log.Info().Msgf("Generating mock")
-	err = gen.Write(out)
-	if err != nil {
-		return err
+	if !this.Config.DryRun {
+		err = gen.Write(out)
+		if err != nil {
+			return err
+		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
Fixes #281.

Adds a dry run option that will not write to files. A debug message has
been added that shows where the file will be written to.

Additionally, we're starting to move towards a new configuration methodology where all objects share the same `Config` struct, instead of having to manually manage them. Just leverage viper.