### PR TITLE
Incorrect import of packages ending in .go

### DIFF
--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -167,9 +167,6 @@ func (g *Generator) getLocalizedPath(ctx context.Context, path string) string {
 	log := zerolog.Ctx(ctx).With().Str(logging.LogKeyPath, path).Logger()
 	ctx = log.WithContext(ctx)
 
-	if strings.HasSuffix(path, ".go") {
-		path, _ = filepath.Split(path)
-	}
 	if localized, ok := g.localizationCache[path]; ok {
 		return localized
 	}


### PR DESCRIPTION
Found the culprit of #249
Not sure why this split was neccessary in the first place. 
Every path is propagated from `Generator.addPackageImport()` where it is returned from `Package.Path()` which cannot be a file path.