### PR TITLE
Removing Deadcode

### DIFF
--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -32,7 +32,6 @@ type Generator struct {
 
 	iface            *Interface
 	pkg              string
-	localPackageName *string
 
 	localizationCache map[string]string
 	packagePathToName map[string]string
@@ -140,10 +139,6 @@ func (g *Generator) importNameExists(name string) bool {
 	return nameExists
 }
 
-func (g *Generator) getLocalizedPathFromPackage(ctx context.Context, pkg *types.Package) string {
-	return g.getLocalizedPath(ctx, pkg.Path())
-}
-
 func calculateImport(ctx context.Context, set []string, path string) string {
 	log := zerolog.Ctx(ctx).With().Str(logging.LogKeyPath, path).Logger()
 	ctx = log.WithContext(ctx)
@@ -218,17 +213,6 @@ func (g *Generator) mockName() string {
 	}
 
 	return g.iface.Name
-}
-
-func (g *Generator) unescapedImportPath(imp *ast.ImportSpec) string {
-	return strings.Replace(imp.Path.Value, "\"", "", -1)
-}
-
-func (g *Generator) getImportStringFromSpec(imp *ast.ImportSpec) string {
-	if name, ok := g.packagePathToName[g.unescapedImportPath(imp)]; ok {
-		return fmt.Sprintf("import %s %s\n", name, imp.Path.Value)
-	}
-	return fmt.Sprintf("import %s\n", imp.Path.Value)
 }
 
 func (g *Generator) sortedImportNames() (importNames []string) {

--- a/pkg/parse_test.go
+++ b/pkg/parse_test.go
@@ -31,20 +31,6 @@ func TestFileParse(t *testing.T) {
 	assert.NotNil(t, node)
 }
 
-func noTestFileInterfaces(t *testing.T) {
-	parser := NewParser(nil)
-
-	err := parser.Parse(ctx, testFile)
-	assert.NoError(t, err)
-
-	err = parser.Load()
-	assert.NoError(t, err)
-
-	nodes := parser.Interfaces()
-	assert.Equal(t, 1, len(nodes))
-	assert.Equal(t, "Requester", nodes[0].Name)
-}
-
 func TestBuildTagInFilename(t *testing.T) {
 	parser := NewParser(nil)
 


### PR DESCRIPTION
Removing unreachable / unused code.

I'm also questioning
```
pkg/fixtures/requester_unexported.go:3:6: `requester_unexported` is unused (deadcode)
```
But there are references to it being used in code gen... I'm not familiar enough yet.

Signed-off-by: Ken Sipe <kensipe@gmail.com>