### PR TITLE
Allow combining --keeptree and --inpackage

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -180,9 +180,6 @@ func (r *RootApp) Run() error {
 	} else {
 		log.Fatal().Msgf("Use --name to specify the name of the interface or --all for all interfaces found")
 	}
-	if r.Config.KeepTree && r.Config.InPackage {
-		log.Fatal().Msgf("--keeptree and --inpackage are mutually exclusive")
-	}
 
 	if r.Config.Profile != "" {
 		f, err := os.Create(r.Config.Profile)

--- a/pkg/fixtures/example_project/foo/foo.go
+++ b/pkg/fixtures/example_project/foo/foo.go
@@ -1,0 +1,11 @@
+package foo
+
+type Baz struct {
+	One string
+	Two int
+}
+
+type Foo interface {
+	DoFoo() string
+	GetBaz() (*Baz, error)
+}

--- a/pkg/fixtures/example_project/root.go
+++ b/pkg/fixtures/example_project/root.go
@@ -1,0 +1,8 @@
+package example_project
+
+import "github.com/vektra/mockery/v2/pkg/fixtures/example_project/foo"
+
+type Root interface {
+	TakesBaz(*foo.Baz)
+	ReturnsFoo() (foo.Foo, error)
+}

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -203,7 +203,7 @@ func (g *Generator) mockName() string {
 		return g.StructName
 	}
 
-	if g.InPackage {
+	if !g.KeepTree && g.InPackage {
 		if ast.IsExported(g.iface.Name) {
 			return "Mock" + g.iface.Name
 		}
@@ -252,7 +252,7 @@ func (g *Generator) generateImports(ctx context.Context) {
 		logImport.Debug().Msgf("found import")
 
 		path := g.nameToPackagePath[name]
-		if g.InPackage && path == pkgPath {
+		if !g.KeepTree && g.InPackage && path == pkgPath {
 			logImport.Debug().Msgf("import (%s) equals interface's package path (%s), skipping", path, pkgPath)
 			continue
 		}
@@ -308,7 +308,7 @@ func (g *Generator) renderType(ctx context.Context, typ types.Type) string {
 	switch t := typ.(type) {
 	case *types.Named:
 		o := t.Obj()
-		if o.Pkg() == nil || o.Pkg().Name() == "main" || (g.InPackage && o.Pkg() == g.iface.Pkg) {
+		if o.Pkg() == nil || o.Pkg().Name() == "main" || (!g.KeepTree && g.InPackage && o.Pkg() == g.iface.Pkg) {
 			return o.Name()
 		}
 		return g.addPackageImport(ctx, o.Pkg()) + "." + o.Name()

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -1170,6 +1170,40 @@ func (_m *Requester2OverrideName) Get(path string) error {
 	s.checkGeneration(testFile2, "Requester2", false, "Requester2OverrideName", expected)
 }
 
+func (s *GeneratorSuite) TestKeepTreeInPackageCombined() {
+	type testData struct {
+		path     string
+		name     string
+		expected string
+	}
+
+	tests := []testData{
+		{path: "example_project/root.go", name: "Root", expected: `package example_project
+
+import example_project "github.com/vektra/mockery/v2/pkg/fixtures/example_project"
+import foo "github.com/vektra/mockery/v2/pkg/fixtures/example_project/foo"
+import mock "github.com/stretchr/testify/mock"
+
+`},
+		{path: "example_project/foo/foo.go", name: "Foo", expected: `package foo
+
+import foo "github.com/vektra/mockery/v2/pkg/fixtures/example_project/foo"
+import mock "github.com/stretchr/testify/mock"
+
+`},
+	}
+
+	for _, test := range tests {
+		generator := NewGenerator(
+			s.ctx,
+			config.Config{InPackage: true, KeepTree: true},
+			s.getInterfaceFromFile(test.path, test.name),
+			pkg,
+		)
+		s.checkPrologueGeneration(generator, test.expected)
+	}
+}
+
 func TestGeneratorSuite(t *testing.T) {
 	generatorSuite := new(GeneratorSuite)
 	suite.Run(t, generatorSuite)

--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -88,7 +88,7 @@ func (this *FileOutputStreamProvider) filename(name string) string {
 		return this.FileName
 	} else if this.InPackage && this.TestOnly {
 		return "mock_" + name + "_test.go"
-	} else if this.InPackage {
+	} else if this.InPackage && !this.KeepTree {
 		return "mock_" + name + ".go"
 	} else if this.TestOnly {
 		return name + "_test.go"

--- a/pkg/outputter_test.go
+++ b/pkg/outputter_test.go
@@ -21,6 +21,11 @@ func TestFilenameMockTest(t *testing.T) {
 	assert.Equal(t, "mock_name_test.go", out.filename("name"))
 }
 
+func TestFilenameKeepTreeInPackage(t *testing.T) {
+	out := FileOutputStreamProvider{KeepTree: true, InPackage: true}
+	assert.Equal(t, "name.go", out.filename("name"))
+}
+
 func TestFilenameTest(t *testing.T) {
 	out := FileOutputStreamProvider{InPackage: false, TestOnly: true}
 	assert.Equal(t, "name_test.go", out.filename("name"))

--- a/pkg/walker.go
+++ b/pkg/walker.go
@@ -130,7 +130,9 @@ func (this *GeneratorVisitor) VisitWalk(ctx context.Context, iface *Interface) e
 	var out io.Writer
 	var pkg string
 
-	if this.InPackage {
+	if this.KeepTree && this.InPackage {
+		pkg = filepath.Dir(iface.FileName)
+	} else if this.InPackage {
 		pkg = filepath.Dir(iface.FileName)
 	} else if (this.PackageName == "" || this.PackageName == "mocks") && this.PackageNamePrefix != "" {
 		// go with package name prefix only when package name is empty or default and package name prefix is specified


### PR DESCRIPTION
This is to resolve #211. I changed `--keeptree` and `--inpackage` to be allowed together rather than modifying existing behavior or adding another flag.