### PR TITLE
Add package load cache

### DIFF
--- a/pkg/parse.go
+++ b/pkg/parse.go
@@ -22,11 +22,17 @@ type parserEntry struct {
 	interfaces []string
 }
 
+type packageLoadEntry struct {
+	pkgs []*packages.Package
+	err  error
+}
+
 type Parser struct {
 	entries           []*parserEntry
 	entriesByFileName map[string]*parserEntry
 	parserPackages    []*types.Package
 	conf              packages.Config
+	packageLoadCache  map[string]packageLoadEntry
 }
 
 func NewParser(buildTags []string) *Parser {
@@ -39,7 +45,17 @@ func NewParser(buildTags []string) *Parser {
 		parserPackages:    make([]*types.Package, 0),
 		entriesByFileName: map[string]*parserEntry{},
 		conf:              conf,
+		packageLoadCache:  map[string]packageLoadEntry{},
 	}
+}
+
+func (p *Parser) loadPackages(fpath string) ([]*packages.Package, error) {
+	if result, ok := p.packageLoadCache[fpath]; ok {
+		return result.pkgs, result.err
+	}
+	pkgs, err := packages.Load(&p.conf, "file="+fpath)
+	p.packageLoadCache[fpath] = packageLoadEntry{pkgs, err}
+	return pkgs, err
 }
 
 func (p *Parser) Parse(ctx context.Context, path string) error {
@@ -81,7 +97,7 @@ func (p *Parser) Parse(ctx context.Context, path string) error {
 			continue
 		}
 
-		pkgs, err := packages.Load(&p.conf, "file="+fpath)
+		pkgs, err := p.loadPackages(fpath)
 		if err != nil {
 			return err
 		}

--- a/pkg/parse.go
+++ b/pkg/parse.go
@@ -85,7 +85,7 @@ func (p *Parser) Parse(ctx context.Context, path string) error {
 			Logger()
 		ctx = log.WithContext(ctx)
 
-		if filepath.Ext(fi.Name()) != ".go" || strings.HasSuffix(fi.Name(), "_test.go") {
+		if filepath.Ext(fi.Name()) != ".go" || strings.HasSuffix(fi.Name(), "_test.go") || strings.HasPrefix(fi.Name(), "mock_") {
 			continue
 		}
 


### PR DESCRIPTION
In our codebase Mockery `v2.6.0` takes about 50 seconds per generated mock. Using `--log-level=trace` revealed that files were getting parsed multiple times: for each file in a folder, `packages.Load` would get called for all files in that folder. In addition to this O(N^2) behavior, when using `--inpackage` Mockery would also parse the previously generated mocks, causing another big slow down for folders with many mocks in them.

The bad performance was successfully mitigated by wrapping the call to `packages.Load()` with a simple cache and skipping files starting with `mock_` (much like the existing filter for `_test.go`). This cut down the runtime of Mockery on our repository from ~40 minutes to ~10 minutes, a ~75% improvement!