### PR TITLE
Add arm64 in goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,7 @@ builds:
       - windows
     goarch:
       - amd64
+      - arm64
 archives:
   - replacements:
       darwin: Darwin


### PR DESCRIPTION
Fixes #382

Goreleaser will automatically build the binary for arm64/v8 on go v1.16