### PR TITLE
Revert "fixed it which mockery's correct version showed."

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,15 +1,10 @@
 package config
 
-import "runtime/debug"
-
 // SemVer is the version of mockery at build time.
 var SemVer = "v0.0.0-dev"
 
 func GetSemverInfo() string {
-	if version, ok := debug.ReadBuildInfo(); ok {
-		return version.Main.Version
-	}
-	return SemVer
+    return SemVer
 }
 
 type Config struct {


### PR DESCRIPTION
Reverts vektra/mockery#386

---

fixes #388
relates to Homebrew/homebrew-core#78314