### PR TITLE
Add Vanilla Mock Generator

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -93,7 +93,7 @@ func init() {
 	pFlags.String("boilerplate-file", "", "File to read a boilerplate text from. Text should be a go block comment, i.e. /* ... */")
 	pFlags.Bool("unroll-variadic", true, "For functions with variadic arguments, do not unroll the arguments into the underlying testify call. Instead, pass variadic slice as-is.")
 	pFlags.Bool("exported", false, "Generates public mocks for private interfaces.")
-
+	pFlags.Bool("vanilla", false, "Generates vanilla mocks")
 	viper.BindPFlags(pFlags)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,7 +4,7 @@ package config
 var SemVer = "v0.0.0-dev"
 
 func GetSemverInfo() string {
-    return SemVer
+	return SemVer
 }
 
 type Config struct {
@@ -39,4 +39,5 @@ type Config struct {
 	TestOnly       bool
 	UnrollVariadic bool `mapstructure:"unroll-variadic"`
 	Version        bool
+	Vanilla        bool
 }

--- a/pkg/fixtures/vaniller_iface.go
+++ b/pkg/fixtures/vaniller_iface.go
@@ -1,0 +1,9 @@
+package test
+
+type Vaniller interface {
+	IntValue() int64
+	StringParam(string)
+	WithName(abc int)
+	Combination(int64) (string, error)
+	Variadic(abc string, more ...string) string
+}

--- a/pkg/vanilla.go
+++ b/pkg/vanilla.go
@@ -1,0 +1,129 @@
+package pkg
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	"go/types"
+	"strings"
+)
+
+func GenerateVanillaMock(interfacePath string, interfaceName string) (*VanillaOutput, error) {
+	parser := NewParser(nil)
+	ctx := context.Background()
+	err := parser.Parse(ctx, interfacePath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = parser.Load()
+
+	if err != nil {
+		return nil, err
+	}
+	iface, err := parser.Find(interfaceName)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if iface == nil {
+		return nil, errors.New("iface is nil")
+	}
+
+	v := VanillaOutput{
+		iface: iface,
+	}
+
+	for _, m := range iface.Methods() {
+		v.parseMethod(m)
+	}
+	return &v, nil
+}
+
+type VanillaOutput struct {
+	iface  *Interface
+	pkg    string
+	fields []string
+	impls  []string
+}
+
+func (v *VanillaOutput) mockStructName() string {
+	return v.iface.Name + "VMock"
+}
+
+func (v *VanillaOutput) ifaceFirstLetter() string {
+	return strings.ToLower(string(v.iface.Name[0]))
+}
+
+func (v *VanillaOutput) addField(fn string) {
+	v.fields = append(v.fields, fn)
+}
+
+func (v *VanillaOutput) addImpl(impl string) {
+	v.impls = append(v.impls, impl)
+}
+
+func (v *VanillaOutput) Output() string {
+	template := `type %s struct %s
+%s
+`
+	name := v.mockStructName()
+	fnsStr := strings.Join(append([]string{"{"}, v.fields...), "\n\t")
+	implsStr := strings.Join(append([]string{"}"}, v.impls...), "\n\n")
+	return fmt.Sprintf(template, name, fnsStr, implsStr)
+}
+
+func (v *VanillaOutput) parseMethod(m *Method) {
+	sig := m.Signature.String()
+	fName := m.Name + "Fn"
+	v.addField(fmt.Sprintf("%s %s", fName, sig))
+
+	params := m.Signature.Params()
+
+	newFnParams := []string{}
+	mockFnInputs := []string{}
+	for i := 0; i < params.Len(); i++ {
+		param := params.At(i)
+		pName := param.Name()
+		pType := param.Type().String()
+
+		if i == params.Len() - 1 && m.Signature.Variadic() {
+			switch t := param.Type().(type) {
+			case *types.Slice:
+				pType = "..." + t.Elem().String()
+			default:
+				panic("bad variadic type!")
+			}
+		}
+
+		if pName == "" {
+			pName = fmt.Sprintf("%s%d", strings.ToLower(string(pType[0])), i)
+		}
+		newParam := fmt.Sprintf("%s %s", pName, pType)
+		newFnParams = append(newFnParams, newParam)
+
+		input := pName
+		if i == params.Len()-1 && m.Signature.Variadic() {
+			input = input + "..."
+		}
+
+		mockFnInputs = append(mockFnInputs, input)
+	}
+
+	newSig := strings.Join(newFnParams, ", ")
+	passArgs := strings.Join(mockFnInputs, ", ")
+	rets := m.Signature.Results().String()
+	receiver := v.mockStructName()
+	iLetter := v.ifaceFirstLetter()
+	ret := "return "
+	if m.Signature.Results().Len() == 0 {
+		ret = ""
+	}
+
+	impl := fmt.Sprintf(`func (%s %s) %s(%s) %s {
+	%s%s.%s(%s)
+}`, iLetter, receiver, m.Name, newSig, rets, ret, iLetter, fName, passArgs)
+	v.addImpl(impl)
+}

--- a/pkg/vanilla_test.go
+++ b/pkg/vanilla_test.go
@@ -1,0 +1,54 @@
+package pkg
+
+import (
+	"github.com/stretchr/testify/assert"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func Test_Vanilla(t *testing.T) {
+	interfacePath := "vanilla_interface.go"
+	interfaceName := "Vaniller"
+	if !strings.Contains(interfacePath, fixturePath) {
+		interfacePath = filepath.Join(fixturePath, interfacePath)
+	}
+	v, err := GenerateVanillaMock(interfacePath, interfaceName)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	expected := `type VanillerVMock struct {
+	CombinationFn func(int64) (string, error)
+	IntValueFn func() int64
+	StringParamFn func(string)
+	VariadicFn func(abc string, more ...string) string
+	WithNameFn func(abc int)
+}
+
+func (v VanillerVMock) Combination(i0 int64) (string, error) {
+	return v.CombinationFn(i0)
+}
+
+func (v VanillerVMock) IntValue() (int64) {
+	return v.IntValueFn()
+}
+
+func (v VanillerVMock) StringParam(s0 string) () {
+	v.StringParamFn(s0)
+}
+
+func (v VanillerVMock) Variadic(abc string, more ...string) (string) {
+	return v.VariadicFn(abc, more...)
+}
+
+func (v VanillerVMock) WithName(abc int) () {
+	v.WithNameFn(abc)
+}
+`
+	actual := v.Output()
+	t.Logf(actual)
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Intention is to generate golang vanilla style mocks. I've piggy backed this repo because there's alot of reusable logic. Would it be better to create a new repo instead? If not would like advice on how to integrate these changes consistently and properly with existing source. `Generator` is a struct instead of an `interface`, so it might get messy.