### PR TITLE
version string logic updated to use v0.0.0-dev when no string set

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,10 +1,23 @@
 package config
 
+import "runtime/debug"
+
+const (
+	_defaultSemVer = "v0.0.0-dev"
+)
+
 // SemVer is the version of mockery at build time.
-var SemVer = "v0.0.0-dev"
+var SemVer = ""
 
 func GetSemverInfo() string {
-    return SemVer
+	if SemVer != "" {
+		return SemVer
+	}
+	version, ok := debug.ReadBuildInfo()
+	if ok && version.Main.Version != "(devel)" {
+		return version.Main.Version
+	}
+	return _defaultSemVer
 }
 
 type Config struct {


### PR DESCRIPTION
This change is aimed at addressing issues where mockery will use the incorrect version if `SemVer` variable is not set during build using the `-ldflag` option.

When running with ld flag set:
```
go build -ldflags="-X 'github.com/vektra/mockery/v2/pkg/config.SemVer=v1.2.3'"
[Fri 12:27] mockery[wb/397]:. ◯ ./mockery --version
Using config file: /home/william/repos/mockery/.mockery.yaml
30 Jul 21 12:27 EDT INF Starting mockery dry-run=false version=v1.2.3
v1.2.3
```

When running as module:
```
[Fri 12:40] ~/repos ◯ mkdir testmodule
[Fri 12:40] ~/repos ◯ cd testmodule
[Fri 12:40] ~/repos/testmodule ◯ go mod init github.com/testmodule
go: creating new go.mod: module github.com/testmodule
[Fri 12:40] ~/repos/testmodule ◯ go get github.com/vektra/mockery/v2/.../@v2.9.0
go get: added github.com/vektra/mockery/v2 v2.9.0
[Fri 12:41] ~/repos/testmodule ◯ go mod edit -replace github.com/vektra/mockery/v2@v2.9.0=../mockery
[Fri 12:41] ~/repos/testmodule ◯ go run github.com/vektra/mockery/v2 --version
30 Jul 21 12:41 EDT INF Starting mockery dry-run=false version=v2.9.0
v2.9.0
```

When running otherwise 
```
go run main.go --version
Using config file: /home/william/repos/mockery/.mockery.yaml
30 Jul 21 12:24 EDT INF Starting mockery dry-run=false version=v0.0.0-dev
v0.0.0-dev
```

closes: #397 