### PR TITLE
Cleanup bad practice object instantiation, fix MOCKERY_CONFIG

### DIFF
--- a/cmd/mockery_test.go
+++ b/cmd/mockery_test.go
@@ -1,1 +1,12 @@
 package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRootCmd(t *testing.T) {
+	cmd := NewRootCmd()
+	assert.Equal(t, "mockery", cmd.Name())
+}

--- a/cmd/showconfig.go
+++ b/cmd/showconfig.go
@@ -10,27 +10,24 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// showconfigCmd represents the showconfig command
-var showconfigCmd = &cobra.Command{
-	Use:   "showconfig",
-	Short: "Show the merged config",
-	Long: `Print out a yaml representation of the merged config. 
-This initializes viper and prints out the merged configuration between
-config files, environment variables, and CLI flags.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		config := &config.Config{}
-		if err := viper.UnmarshalExact(config); err != nil {
-			return errors.Wrapf(err, "failed to unmarshal config")
-		}
-		out, err := yaml.Marshal(config)
-		if err != nil {
-			return errors.Wrapf(err, "Failed to marsrhal yaml")
-		}
-		fmt.Printf("%s", string(out))
-		return nil
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(showconfigCmd)
+func NewShowConfigCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "showconfig",
+		Short: "Show the merged config",
+		Long: `Print out a yaml representation of the merged config. 
+	This initializes viper and prints out the merged configuration between
+	config files, environment variables, and CLI flags.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			config := &config.Config{}
+			if err := viper.UnmarshalExact(config); err != nil {
+				return errors.Wrapf(err, "failed to unmarshal config")
+			}
+			out, err := yaml.Marshal(config)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to marsrhal yaml")
+			}
+			fmt.Printf("%s", string(out))
+			return nil
+		},
+	}
 }

--- a/cmd/showconfig_test.go
+++ b/cmd/showconfig_test.go
@@ -1,0 +1,12 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewShowConfigCmd(t *testing.T) {
+	cmd := NewShowConfigCmd()
+	assert.Equal(t, "showconfig", cmd.Name())
+}


### PR DESCRIPTION
This fixes #407. Also doing some minor cleanup with how the command
objects are instantiated. The default way cobra creates the commands is
by setting global variables, which is yucky. This adds constructor
functions.

```bash
[ltclipp@landon-virtualbox mockery]$ go build .
[ltclipp@landon-virtualbox mockery]$ cd ..
[ltclipp@landon-virtualbox vektra]$ export MOCKERY_CONFIG=$(readlink -f ./mockery/.mockery.yaml)
[ltclipp@landon-virtualbox vektra]$ echo $MOCKERY_CONFIG
/home/ltclipp/git/vektra/mockery/.mockery.yaml
[ltclipp@landon-virtualbox vektra]$ ./mockery/mockery showconfig |& grep Using
Using config file: /home/ltclipp/git/vektra/mockery/.mockery.yaml
```