### PR TITLE
Load packages with dependencies for Go 1.18

### DIFF
--- a/pkg/parse.go
+++ b/pkg/parse.go
@@ -37,7 +37,7 @@ type Parser struct {
 
 func NewParser(buildTags []string) *Parser {
 	var conf packages.Config
-	conf.Mode = packages.LoadSyntax
+	conf.Mode = packages.LoadSyntax | packages.NeedDeps
 	if len(buildTags) > 0 {
 		conf.BuildFlags = []string{"-tags", strings.Join(buildTags, ",")}
 	}


### PR DESCRIPTION
Without the additional `NeedDeps` mockery fails with:
"Unexpected package creation during export data loading"

Refs #434