### PR TITLE
Test with Go 1.18 and fix GetSemverInfo()

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-latest, ubuntu-latest]
-        go_vers: [1.16, 1.17]
+        go_vers: [1.16, 1.17, 1.18]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,7 +14,7 @@ func GetSemverInfo() string {
 		return SemVer
 	}
 	version, ok := debug.ReadBuildInfo()
-	if ok && version.Main.Version != "(devel)" {
+	if ok && version.Main.Version != "(devel)" && version.Main.Version != "" {
 		return version.Main.Version
 	}
 	return _defaultSemVer


### PR DESCRIPTION
`debug.ReadBuildInfo()` changed its behavior since Go 1.18 which caused a test failure in `TestGeneratorSuite/TestGeneratorPrologueNote`.