### PR TITLE
fix: allow configuring flags with "-" as environment variables

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -106,6 +106,7 @@ func Execute() {
 
 func initConfig() {
 	viper.SetEnvPrefix("mockery")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 
 	if cfgFile != "" {

--- a/cmd/mockery_test.go
+++ b/cmd/mockery_test.go
@@ -1,12 +1,91 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vektra/mockery/v2/pkg/config"
 )
 
 func TestNewRootCmd(t *testing.T) {
 	cmd := NewRootCmd()
 	assert.Equal(t, "mockery", cmd.Name())
+}
+
+func TestConfigEnvFlags(t *testing.T) {
+	expected := config.Config{
+		Config:               "my_file.yaml",
+		Name:                 "SomeInterface",
+		Print:                true,
+		Output:               "/some/dir",
+		Outpkg:               "some/package",
+		Packageprefix:        "prefix_",
+		Dir:                  "dir/to/search",
+		Recursive:            true,
+		All:                  true,
+		InPackage:            true,
+		TestOnly:             true,
+		Case:                 "underscore",
+		Note:                 "// this is a test",
+		Cpuprofile:           "test.pprof",
+		Version:              true,
+		KeepTree:             true,
+		BuildTags:            "test mock",
+		FileName:             "my-file.go",
+		StructName:           "Interface1",
+		LogLevel:             "warn",
+		SrcPkg:               "some/other/package",
+		DryRun:               true,
+		DisableVersionString: true,
+		BoilerplateFile:      "some/file",
+		UnrollVariadic:       false,
+		Exported:             true,
+		WithExpecter:         true,
+	}
+
+	env(t, "CONFIG", expected.Config)
+	env(t, "NAME", expected.Name)
+	env(t, "PRINT", fmt.Sprint(expected.Print))
+	env(t, "OUTPUT", expected.Output)
+	env(t, "OUTPKG", expected.Outpkg)
+	env(t, "PACKAGEPREFIX", expected.Packageprefix)
+	env(t, "DIR", expected.Dir)
+	env(t, "RECURSIVE", fmt.Sprint(expected.Recursive))
+	env(t, "ALL", fmt.Sprint(expected.All))
+	env(t, "INPACKAGE", fmt.Sprint(expected.InPackage))
+	env(t, "TESTONLY", fmt.Sprint(expected.TestOnly))
+	env(t, "CASE", expected.Case)
+	env(t, "NOTE", expected.Note)
+	env(t, "CPUPROFILE", expected.Cpuprofile)
+	env(t, "VERSION", fmt.Sprint(expected.Version))
+	env(t, "QUIET", fmt.Sprint(expected.Quiet))
+	env(t, "KEEPTREE", fmt.Sprint(expected.KeepTree))
+	env(t, "TAGS", expected.BuildTags)
+	env(t, "FILENAME", expected.FileName)
+	env(t, "STRUCTNAME", expected.StructName)
+	env(t, "LOG_LEVEL", expected.LogLevel)
+	env(t, "SRCPKG", expected.SrcPkg)
+	env(t, "DRY_RUN", fmt.Sprint(expected.DryRun))
+	env(t, "DISABLE_VERSION_STRING", fmt.Sprint(expected.DisableVersionString))
+	env(t, "BOILERPLATE_FILE", expected.BoilerplateFile)
+	env(t, "UNROLL_VARIADIC", fmt.Sprint(expected.UnrollVariadic))
+	env(t, "EXPORTED", fmt.Sprint(expected.Exported))
+	env(t, "WITH_EXPECTER", fmt.Sprint(expected.WithExpecter))
+
+	initConfig()
+
+	app, err := GetRootAppFromViper(viper.GetViper())
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, app.Config)
+}
+
+func env(t *testing.T, key, value string) {
+	key = "MOCKERY_" + key
+	t.Cleanup(func() { os.Unsetenv(key) })
+	os.Setenv(key, value)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,7 +48,6 @@ type Config struct {
 	// StructName overrides the name given to the mock struct and should only be nonempty
 	// when generating for an exact match (non regex expression in -name).
 	StructName     string
-	Tags           string
 	TestOnly       bool
 	UnrollVariadic bool `mapstructure:"unroll-variadic"`
 	Version        bool


### PR DESCRIPTION
Dashes are not allowed in variable names in most shells. While you can work around this with `env`, this doesn't work when you want to `export` it as a global env var (because shells will also ignore env variables with dashes in them).

For example MOCKERY_DISABLE_VERSION_STRING.

So, this workaround works:
```
➜ env "MOCKERY_DISABLE-VERSION-STRING=true" mockery showconfig | grep versionstring
disableversionstring: true
```

But this doesn't:
```shell
➜ MOCKERY_DISABLE_VERSION_STRING=true mockery showconfig | grep versionstring
disableversionstring: false
```

After this fix, we can use it:
```shell
➜ MOCKERY_DISABLE_VERSION_STRING=true ./mockery showconfig | grep versionstring
disableversionstring: true
```