### PR TITLE
Add testing.TB to mock.Mock in constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ func (m *Stringer) String() string {
 	return r0
 }
 
-// NewStringer creates a new instance of Stringer. It also registers a cleanup function to assert the mocks expectations.
+// NewStringer creates a new instance of Stringer. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewStringer(t testing.TB) *Stringer {
 	mock := &Stringer{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -165,9 +166,10 @@ func (_m *SendFunc) Execute(data string) (int, error) {
 	return r0, r1
 }
 
-// NewSendFunc creates a new instance of SendFunc. It also registers a cleanup function to assert the mocks expectations.
+// NewSendFunc creates a new instance of SendFunc. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewSendFunc(t testing.TB) *SendFunc {
 	mock := &SendFunc{}
+    mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -332,6 +334,7 @@ less error-prone (you won't have to worry about forgetting the `AssertExpectatio
 Before v2.11:
 ```go
 factory := &mocks.Factory{}
+factory.Test(t) // so that mock does not panic when a method is unexpected
 defer factory.AssertExpectations(t)
 ```
 
@@ -340,7 +343,9 @@ After v2.11:
 factory := mocks.NewFactory(t)
 ```
 
-The `AssertExpectations` method is registered automatically inside the constructor via `t.Cleanup()` method.
+The constructor sets up common functionalities automatically
+- The `AssertExpectations` method is registered to be called at the end of the tests via `t.Cleanup()` method.
+- The testing.TB interface is registered on the `mock.Mock` so that tests don't panic when a call on the mock is unexpected.
 
 Extended Flag Descriptions
 --------------------------

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ func (_m *SendFunc) Execute(data string) (int, error) {
 // NewSendFunc creates a new instance of SendFunc. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewSendFunc(t testing.TB) *SendFunc {
 	mock := &SendFunc{}
-    mock.Mock.Test(t)
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/cmd/stackTracer.go
+++ b/mocks/cmd/stackTracer.go
@@ -30,7 +30,7 @@ func (_m *stackTracer) StackTrace() errors.StackTrace {
 	return r0
 }
 
-// newStackTracer creates a new instance of stackTracer. It also registers a cleanup function to assert the mocks expectations.
+// newStackTracer creates a new instance of stackTracer. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func newStackTracer(t testing.TB) *stackTracer {
 	mock := &stackTracer{}
 

--- a/mocks/pkg/Cleanup.go
+++ b/mocks/pkg/Cleanup.go
@@ -27,7 +27,7 @@ func (_m *Cleanup) Execute() error {
 	return r0
 }
 
-// NewCleanup creates a new instance of Cleanup. It also registers a cleanup function to assert the mocks expectations.
+// NewCleanup creates a new instance of Cleanup. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewCleanup(t testing.TB) *Cleanup {
 	mock := &Cleanup{}
 

--- a/mocks/pkg/OutputStreamProvider.go
+++ b/mocks/pkg/OutputStreamProvider.go
@@ -50,7 +50,7 @@ func (_m *OutputStreamProvider) GetWriter(_a0 context.Context, _a1 *pkg.Interfac
 	return r0, r1, r2
 }
 
-// NewOutputStreamProvider creates a new instance of OutputStreamProvider. It also registers a cleanup function to assert the mocks expectations.
+// NewOutputStreamProvider creates a new instance of OutputStreamProvider. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewOutputStreamProvider(t testing.TB) *OutputStreamProvider {
 	mock := &OutputStreamProvider{}
 

--- a/mocks/pkg/WalkerVisitor.go
+++ b/mocks/pkg/WalkerVisitor.go
@@ -30,7 +30,7 @@ func (_m *WalkerVisitor) VisitWalk(_a0 context.Context, _a1 *pkg.Interface) erro
 	return r0
 }
 
-// NewWalkerVisitor creates a new instance of WalkerVisitor. It also registers a cleanup function to assert the mocks expectations.
+// NewWalkerVisitor creates a new instance of WalkerVisitor. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewWalkerVisitor(t testing.TB) *WalkerVisitor {
 	mock := &WalkerVisitor{}
 

--- a/mocks/pkg/fixtures/A.go
+++ b/mocks/pkg/fixtures/A.go
@@ -38,6 +38,7 @@ func (_m *A) Call() (test.B, error) {
 // NewA creates a new instance of A. It also registers a cleanup function to assert the mocks expectations.
 func NewA(t testing.TB) *A {
 	mock := &A{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/A.go
+++ b/mocks/pkg/fixtures/A.go
@@ -35,7 +35,7 @@ func (_m *A) Call() (test.B, error) {
 	return r0, r1
 }
 
-// NewA creates a new instance of A. It also registers a cleanup function to assert the mocks expectations.
+// NewA creates a new instance of A. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewA(t testing.TB) *A {
 	mock := &A{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/AsyncProducer.go
+++ b/mocks/pkg/fixtures/AsyncProducer.go
@@ -64,6 +64,7 @@ func (_m *AsyncProducer) Whatever() chan bool {
 // NewAsyncProducer creates a new instance of AsyncProducer. It also registers a cleanup function to assert the mocks expectations.
 func NewAsyncProducer(t testing.TB) *AsyncProducer {
 	mock := &AsyncProducer{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/AsyncProducer.go
+++ b/mocks/pkg/fixtures/AsyncProducer.go
@@ -61,7 +61,7 @@ func (_m *AsyncProducer) Whatever() chan bool {
 	return r0
 }
 
-// NewAsyncProducer creates a new instance of AsyncProducer. It also registers a cleanup function to assert the mocks expectations.
+// NewAsyncProducer creates a new instance of AsyncProducer. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewAsyncProducer(t testing.TB) *AsyncProducer {
 	mock := &AsyncProducer{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/Blank.go
+++ b/mocks/pkg/fixtures/Blank.go
@@ -27,7 +27,7 @@ func (_m *Blank) Create(x interface{}) error {
 	return r0
 }
 
-// NewBlank creates a new instance of Blank. It also registers a cleanup function to assert the mocks expectations.
+// NewBlank creates a new instance of Blank. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewBlank(t testing.TB) *Blank {
 	mock := &Blank{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/Blank.go
+++ b/mocks/pkg/fixtures/Blank.go
@@ -30,6 +30,7 @@ func (_m *Blank) Create(x interface{}) error {
 // NewBlank creates a new instance of Blank. It also registers a cleanup function to assert the mocks expectations.
 func NewBlank(t testing.TB) *Blank {
 	mock := &Blank{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/ConsulLock.go
+++ b/mocks/pkg/fixtures/ConsulLock.go
@@ -50,7 +50,7 @@ func (_m *ConsulLock) Unlock() error {
 	return r0
 }
 
-// NewConsulLock creates a new instance of ConsulLock. It also registers a cleanup function to assert the mocks expectations.
+// NewConsulLock creates a new instance of ConsulLock. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewConsulLock(t testing.TB) *ConsulLock {
 	mock := &ConsulLock{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/ConsulLock.go
+++ b/mocks/pkg/fixtures/ConsulLock.go
@@ -53,6 +53,7 @@ func (_m *ConsulLock) Unlock() error {
 // NewConsulLock creates a new instance of ConsulLock. It also registers a cleanup function to assert the mocks expectations.
 func NewConsulLock(t testing.TB) *ConsulLock {
 	mock := &ConsulLock{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/Example.go
+++ b/mocks/pkg/fixtures/Example.go
@@ -47,7 +47,7 @@ func (_m *Example) B(_a0 string) fixtureshttp.MyStruct {
 	return r0
 }
 
-// NewExample creates a new instance of Example. It also registers a cleanup function to assert the mocks expectations.
+// NewExample creates a new instance of Example. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewExample(t testing.TB) *Example {
 	mock := &Example{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/Example.go
+++ b/mocks/pkg/fixtures/Example.go
@@ -50,6 +50,7 @@ func (_m *Example) B(_a0 string) fixtureshttp.MyStruct {
 // NewExample creates a new instance of Example. It also registers a cleanup function to assert the mocks expectations.
 func NewExample(t testing.TB) *Example {
 	mock := &Example{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/ExpecterTest.go
+++ b/mocks/pkg/fixtures/ExpecterTest.go
@@ -92,7 +92,7 @@ func (_m *ExpecterTest) VariadicMany(i int, a string, intfs ...interface{}) erro
 	return r0
 }
 
-// NewExpecterTest creates a new instance of ExpecterTest. It also registers a cleanup function to assert the mocks expectations.
+// NewExpecterTest creates a new instance of ExpecterTest. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewExpecterTest(t testing.TB) *ExpecterTest {
 	mock := &ExpecterTest{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/ExpecterTest.go
+++ b/mocks/pkg/fixtures/ExpecterTest.go
@@ -95,6 +95,7 @@ func (_m *ExpecterTest) VariadicMany(i int, a string, intfs ...interface{}) erro
 // NewExpecterTest creates a new instance of ExpecterTest. It also registers a cleanup function to assert the mocks expectations.
 func NewExpecterTest(t testing.TB) *ExpecterTest {
 	mock := &ExpecterTest{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/Fooer.go
+++ b/mocks/pkg/fixtures/Fooer.go
@@ -48,7 +48,7 @@ func (_m *Fooer) Foo(f func(string) string) error {
 	return r0
 }
 
-// NewFooer creates a new instance of Fooer. It also registers a cleanup function to assert the mocks expectations.
+// NewFooer creates a new instance of Fooer. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewFooer(t testing.TB) *Fooer {
 	mock := &Fooer{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/Fooer.go
+++ b/mocks/pkg/fixtures/Fooer.go
@@ -51,6 +51,7 @@ func (_m *Fooer) Foo(f func(string) string) error {
 // NewFooer creates a new instance of Fooer. It also registers a cleanup function to assert the mocks expectations.
 func NewFooer(t testing.TB) *Fooer {
 	mock := &Fooer{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/FuncArgsCollision.go
+++ b/mocks/pkg/fixtures/FuncArgsCollision.go
@@ -27,7 +27,7 @@ func (_m *FuncArgsCollision) Foo(ret interface{}) error {
 	return r0
 }
 
-// NewFuncArgsCollision creates a new instance of FuncArgsCollision. It also registers a cleanup function to assert the mocks expectations.
+// NewFuncArgsCollision creates a new instance of FuncArgsCollision. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewFuncArgsCollision(t testing.TB) *FuncArgsCollision {
 	mock := &FuncArgsCollision{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/FuncArgsCollision.go
+++ b/mocks/pkg/fixtures/FuncArgsCollision.go
@@ -30,6 +30,7 @@ func (_m *FuncArgsCollision) Foo(ret interface{}) error {
 // NewFuncArgsCollision creates a new instance of FuncArgsCollision. It also registers a cleanup function to assert the mocks expectations.
 func NewFuncArgsCollision(t testing.TB) *FuncArgsCollision {
 	mock := &FuncArgsCollision{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/HasConflictingNestedImports.go
+++ b/mocks/pkg/fixtures/HasConflictingNestedImports.go
@@ -52,7 +52,7 @@ func (_m *HasConflictingNestedImports) Z() fixtureshttp.MyStruct {
 	return r0
 }
 
-// NewHasConflictingNestedImports creates a new instance of HasConflictingNestedImports. It also registers a cleanup function to assert the mocks expectations.
+// NewHasConflictingNestedImports creates a new instance of HasConflictingNestedImports. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewHasConflictingNestedImports(t testing.TB) *HasConflictingNestedImports {
 	mock := &HasConflictingNestedImports{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/HasConflictingNestedImports.go
+++ b/mocks/pkg/fixtures/HasConflictingNestedImports.go
@@ -55,6 +55,7 @@ func (_m *HasConflictingNestedImports) Z() fixtureshttp.MyStruct {
 // NewHasConflictingNestedImports creates a new instance of HasConflictingNestedImports. It also registers a cleanup function to assert the mocks expectations.
 func NewHasConflictingNestedImports(t testing.TB) *HasConflictingNestedImports {
 	mock := &HasConflictingNestedImports{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/ImportsSameAsPackage.go
+++ b/mocks/pkg/fixtures/ImportsSameAsPackage.go
@@ -54,6 +54,7 @@ func (_m *ImportsSameAsPackage) C(_a0 fixtures.C) {
 // NewImportsSameAsPackage creates a new instance of ImportsSameAsPackage. It also registers a cleanup function to assert the mocks expectations.
 func NewImportsSameAsPackage(t testing.TB) *ImportsSameAsPackage {
 	mock := &ImportsSameAsPackage{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/ImportsSameAsPackage.go
+++ b/mocks/pkg/fixtures/ImportsSameAsPackage.go
@@ -51,7 +51,7 @@ func (_m *ImportsSameAsPackage) C(_a0 fixtures.C) {
 	_m.Called(_a0)
 }
 
-// NewImportsSameAsPackage creates a new instance of ImportsSameAsPackage. It also registers a cleanup function to assert the mocks expectations.
+// NewImportsSameAsPackage creates a new instance of ImportsSameAsPackage. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewImportsSameAsPackage(t testing.TB) *ImportsSameAsPackage {
 	mock := &ImportsSameAsPackage{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/KeyManager.go
+++ b/mocks/pkg/fixtures/KeyManager.go
@@ -39,7 +39,7 @@ func (_m *KeyManager) GetKey(_a0 string, _a1 uint16) ([]byte, *test.Err) {
 	return r0, r1
 }
 
-// NewKeyManager creates a new instance of KeyManager. It also registers a cleanup function to assert the mocks expectations.
+// NewKeyManager creates a new instance of KeyManager. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewKeyManager(t testing.TB) *KeyManager {
 	mock := &KeyManager{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/KeyManager.go
+++ b/mocks/pkg/fixtures/KeyManager.go
@@ -42,6 +42,7 @@ func (_m *KeyManager) GetKey(_a0 string, _a1 uint16) ([]byte, *test.Err) {
 // NewKeyManager creates a new instance of KeyManager. It also registers a cleanup function to assert the mocks expectations.
 func NewKeyManager(t testing.TB) *KeyManager {
 	mock := &KeyManager{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/MapFunc.go
+++ b/mocks/pkg/fixtures/MapFunc.go
@@ -30,6 +30,7 @@ func (_m *MapFunc) Get(m map[string]func(string) string) error {
 // NewMapFunc creates a new instance of MapFunc. It also registers a cleanup function to assert the mocks expectations.
 func NewMapFunc(t testing.TB) *MapFunc {
 	mock := &MapFunc{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/MapFunc.go
+++ b/mocks/pkg/fixtures/MapFunc.go
@@ -27,7 +27,7 @@ func (_m *MapFunc) Get(m map[string]func(string) string) error {
 	return r0
 }
 
-// NewMapFunc creates a new instance of MapFunc. It also registers a cleanup function to assert the mocks expectations.
+// NewMapFunc creates a new instance of MapFunc. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewMapFunc(t testing.TB) *MapFunc {
 	mock := &MapFunc{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/MapToInterface.go
+++ b/mocks/pkg/fixtures/MapToInterface.go
@@ -27,6 +27,7 @@ func (_m *MapToInterface) Foo(arg1 ...map[string]interface{}) {
 // NewMapToInterface creates a new instance of MapToInterface. It also registers a cleanup function to assert the mocks expectations.
 func NewMapToInterface(t testing.TB) *MapToInterface {
 	mock := &MapToInterface{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/MapToInterface.go
+++ b/mocks/pkg/fixtures/MapToInterface.go
@@ -24,7 +24,7 @@ func (_m *MapToInterface) Foo(arg1 ...map[string]interface{}) {
 	_m.Called(_ca...)
 }
 
-// NewMapToInterface creates a new instance of MapToInterface. It also registers a cleanup function to assert the mocks expectations.
+// NewMapToInterface creates a new instance of MapToInterface. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewMapToInterface(t testing.TB) *MapToInterface {
 	mock := &MapToInterface{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/MyReader.go
+++ b/mocks/pkg/fixtures/MyReader.go
@@ -37,6 +37,7 @@ func (_m *MyReader) Read(p []byte) (int, error) {
 // NewMyReader creates a new instance of MyReader. It also registers a cleanup function to assert the mocks expectations.
 func NewMyReader(t testing.TB) *MyReader {
 	mock := &MyReader{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/MyReader.go
+++ b/mocks/pkg/fixtures/MyReader.go
@@ -34,7 +34,7 @@ func (_m *MyReader) Read(p []byte) (int, error) {
 	return r0, r1
 }
 
-// NewMyReader creates a new instance of MyReader. It also registers a cleanup function to assert the mocks expectations.
+// NewMyReader creates a new instance of MyReader. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewMyReader(t testing.TB) *MyReader {
 	mock := &MyReader{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/Requester.go
+++ b/mocks/pkg/fixtures/Requester.go
@@ -37,6 +37,7 @@ func (_m *Requester) Get(path string) (string, error) {
 // NewRequester creates a new instance of Requester. It also registers a cleanup function to assert the mocks expectations.
 func NewRequester(t testing.TB) *Requester {
 	mock := &Requester{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/Requester.go
+++ b/mocks/pkg/fixtures/Requester.go
@@ -34,7 +34,7 @@ func (_m *Requester) Get(path string) (string, error) {
 	return r0, r1
 }
 
-// NewRequester creates a new instance of Requester. It also registers a cleanup function to assert the mocks expectations.
+// NewRequester creates a new instance of Requester. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequester(t testing.TB) *Requester {
 	mock := &Requester{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/Requester2.go
+++ b/mocks/pkg/fixtures/Requester2.go
@@ -30,6 +30,7 @@ func (_m *Requester2) Get(path string) error {
 // NewRequester2 creates a new instance of Requester2. It also registers a cleanup function to assert the mocks expectations.
 func NewRequester2(t testing.TB) *Requester2 {
 	mock := &Requester2{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/Requester2.go
+++ b/mocks/pkg/fixtures/Requester2.go
@@ -27,7 +27,7 @@ func (_m *Requester2) Get(path string) error {
 	return r0
 }
 
-// NewRequester2 creates a new instance of Requester2. It also registers a cleanup function to assert the mocks expectations.
+// NewRequester2 creates a new instance of Requester2. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequester2(t testing.TB) *Requester2 {
 	mock := &Requester2{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/Requester3.go
+++ b/mocks/pkg/fixtures/Requester3.go
@@ -30,6 +30,7 @@ func (_m *Requester3) Get() error {
 // NewRequester3 creates a new instance of Requester3. It also registers a cleanup function to assert the mocks expectations.
 func NewRequester3(t testing.TB) *Requester3 {
 	mock := &Requester3{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/Requester3.go
+++ b/mocks/pkg/fixtures/Requester3.go
@@ -27,7 +27,7 @@ func (_m *Requester3) Get() error {
 	return r0
 }
 
-// NewRequester3 creates a new instance of Requester3. It also registers a cleanup function to assert the mocks expectations.
+// NewRequester3 creates a new instance of Requester3. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequester3(t testing.TB) *Requester3 {
 	mock := &Requester3{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/Requester4.go
+++ b/mocks/pkg/fixtures/Requester4.go
@@ -21,6 +21,7 @@ func (_m *Requester4) Get() {
 // NewRequester4 creates a new instance of Requester4. It also registers a cleanup function to assert the mocks expectations.
 func NewRequester4(t testing.TB) *Requester4 {
 	mock := &Requester4{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/Requester4.go
+++ b/mocks/pkg/fixtures/Requester4.go
@@ -18,7 +18,7 @@ func (_m *Requester4) Get() {
 	_m.Called()
 }
 
-// NewRequester4 creates a new instance of Requester4. It also registers a cleanup function to assert the mocks expectations.
+// NewRequester4 creates a new instance of Requester4. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequester4(t testing.TB) *Requester4 {
 	mock := &Requester4{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/RequesterArgSameAsImport.go
+++ b/mocks/pkg/fixtures/RequesterArgSameAsImport.go
@@ -31,7 +31,7 @@ func (_m *RequesterArgSameAsImport) Get(_a0 string) *json.RawMessage {
 	return r0
 }
 
-// NewRequesterArgSameAsImport creates a new instance of RequesterArgSameAsImport. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterArgSameAsImport creates a new instance of RequesterArgSameAsImport. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterArgSameAsImport(t testing.TB) *RequesterArgSameAsImport {
 	mock := &RequesterArgSameAsImport{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/RequesterArgSameAsImport.go
+++ b/mocks/pkg/fixtures/RequesterArgSameAsImport.go
@@ -34,6 +34,7 @@ func (_m *RequesterArgSameAsImport) Get(_a0 string) *json.RawMessage {
 // NewRequesterArgSameAsImport creates a new instance of RequesterArgSameAsImport. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterArgSameAsImport(t testing.TB) *RequesterArgSameAsImport {
 	mock := &RequesterArgSameAsImport{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/RequesterArgSameAsNamedImport.go
+++ b/mocks/pkg/fixtures/RequesterArgSameAsNamedImport.go
@@ -31,7 +31,7 @@ func (_m *RequesterArgSameAsNamedImport) Get(_a0 string) *json.RawMessage {
 	return r0
 }
 
-// NewRequesterArgSameAsNamedImport creates a new instance of RequesterArgSameAsNamedImport. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterArgSameAsNamedImport creates a new instance of RequesterArgSameAsNamedImport. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterArgSameAsNamedImport(t testing.TB) *RequesterArgSameAsNamedImport {
 	mock := &RequesterArgSameAsNamedImport{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/RequesterArgSameAsNamedImport.go
+++ b/mocks/pkg/fixtures/RequesterArgSameAsNamedImport.go
@@ -34,6 +34,7 @@ func (_m *RequesterArgSameAsNamedImport) Get(_a0 string) *json.RawMessage {
 // NewRequesterArgSameAsNamedImport creates a new instance of RequesterArgSameAsNamedImport. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterArgSameAsNamedImport(t testing.TB) *RequesterArgSameAsNamedImport {
 	mock := &RequesterArgSameAsNamedImport{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/RequesterArgSameAsPkg.go
+++ b/mocks/pkg/fixtures/RequesterArgSameAsPkg.go
@@ -18,7 +18,7 @@ func (_m *RequesterArgSameAsPkg) Get(_a0 string) {
 	_m.Called(_a0)
 }
 
-// NewRequesterArgSameAsPkg creates a new instance of RequesterArgSameAsPkg. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterArgSameAsPkg creates a new instance of RequesterArgSameAsPkg. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterArgSameAsPkg(t testing.TB) *RequesterArgSameAsPkg {
 	mock := &RequesterArgSameAsPkg{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/RequesterArgSameAsPkg.go
+++ b/mocks/pkg/fixtures/RequesterArgSameAsPkg.go
@@ -21,6 +21,7 @@ func (_m *RequesterArgSameAsPkg) Get(_a0 string) {
 // NewRequesterArgSameAsPkg creates a new instance of RequesterArgSameAsPkg. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterArgSameAsPkg(t testing.TB) *RequesterArgSameAsPkg {
 	mock := &RequesterArgSameAsPkg{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/RequesterArray.go
+++ b/mocks/pkg/fixtures/RequesterArray.go
@@ -36,7 +36,7 @@ func (_m *RequesterArray) Get(path string) ([2]string, error) {
 	return r0, r1
 }
 
-// NewRequesterArray creates a new instance of RequesterArray. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterArray creates a new instance of RequesterArray. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterArray(t testing.TB) *RequesterArray {
 	mock := &RequesterArray{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/RequesterArray.go
+++ b/mocks/pkg/fixtures/RequesterArray.go
@@ -39,6 +39,7 @@ func (_m *RequesterArray) Get(path string) ([2]string, error) {
 // NewRequesterArray creates a new instance of RequesterArray. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterArray(t testing.TB) *RequesterArray {
 	mock := &RequesterArray{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/RequesterElided.go
+++ b/mocks/pkg/fixtures/RequesterElided.go
@@ -30,6 +30,7 @@ func (_m *RequesterElided) Get(path string, url string) error {
 // NewRequesterElided creates a new instance of RequesterElided. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterElided(t testing.TB) *RequesterElided {
 	mock := &RequesterElided{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/RequesterElided.go
+++ b/mocks/pkg/fixtures/RequesterElided.go
@@ -27,7 +27,7 @@ func (_m *RequesterElided) Get(path string, url string) error {
 	return r0
 }
 
-// NewRequesterElided creates a new instance of RequesterElided. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterElided creates a new instance of RequesterElided. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterElided(t testing.TB) *RequesterElided {
 	mock := &RequesterElided{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/RequesterIface.go
+++ b/mocks/pkg/fixtures/RequesterIface.go
@@ -34,6 +34,7 @@ func (_m *RequesterIface) Get() io.Reader {
 // NewRequesterIface creates a new instance of RequesterIface. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterIface(t testing.TB) *RequesterIface {
 	mock := &RequesterIface{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/RequesterIface.go
+++ b/mocks/pkg/fixtures/RequesterIface.go
@@ -31,7 +31,7 @@ func (_m *RequesterIface) Get() io.Reader {
 	return r0
 }
 
-// NewRequesterIface creates a new instance of RequesterIface. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterIface creates a new instance of RequesterIface. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterIface(t testing.TB) *RequesterIface {
 	mock := &RequesterIface{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/RequesterNS.go
+++ b/mocks/pkg/fixtures/RequesterNS.go
@@ -36,7 +36,7 @@ func (_m *RequesterNS) Get(path string) (http.Response, error) {
 	return r0, r1
 }
 
-// NewRequesterNS creates a new instance of RequesterNS. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterNS creates a new instance of RequesterNS. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterNS(t testing.TB) *RequesterNS {
 	mock := &RequesterNS{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/RequesterNS.go
+++ b/mocks/pkg/fixtures/RequesterNS.go
@@ -39,6 +39,7 @@ func (_m *RequesterNS) Get(path string) (http.Response, error) {
 // NewRequesterNS creates a new instance of RequesterNS. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterNS(t testing.TB) *RequesterNS {
 	mock := &RequesterNS{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/RequesterPtr.go
+++ b/mocks/pkg/fixtures/RequesterPtr.go
@@ -39,6 +39,7 @@ func (_m *RequesterPtr) Get(path string) (*string, error) {
 // NewRequesterPtr creates a new instance of RequesterPtr. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterPtr(t testing.TB) *RequesterPtr {
 	mock := &RequesterPtr{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/RequesterPtr.go
+++ b/mocks/pkg/fixtures/RequesterPtr.go
@@ -36,7 +36,7 @@ func (_m *RequesterPtr) Get(path string) (*string, error) {
 	return r0, r1
 }
 
-// NewRequesterPtr creates a new instance of RequesterPtr. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterPtr creates a new instance of RequesterPtr. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterPtr(t testing.TB) *RequesterPtr {
 	mock := &RequesterPtr{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/RequesterReturnElided.go
+++ b/mocks/pkg/fixtures/RequesterReturnElided.go
@@ -51,6 +51,7 @@ func (_m *RequesterReturnElided) Get(path string) (int, int, int, error) {
 // NewRequesterReturnElided creates a new instance of RequesterReturnElided. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterReturnElided(t testing.TB) *RequesterReturnElided {
 	mock := &RequesterReturnElided{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/RequesterReturnElided.go
+++ b/mocks/pkg/fixtures/RequesterReturnElided.go
@@ -48,7 +48,7 @@ func (_m *RequesterReturnElided) Get(path string) (int, int, int, error) {
 	return r0, r1, r2, r3
 }
 
-// NewRequesterReturnElided creates a new instance of RequesterReturnElided. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterReturnElided creates a new instance of RequesterReturnElided. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterReturnElided(t testing.TB) *RequesterReturnElided {
 	mock := &RequesterReturnElided{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/RequesterSlice.go
+++ b/mocks/pkg/fixtures/RequesterSlice.go
@@ -36,7 +36,7 @@ func (_m *RequesterSlice) Get(path string) ([]string, error) {
 	return r0, r1
 }
 
-// NewRequesterSlice creates a new instance of RequesterSlice. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterSlice creates a new instance of RequesterSlice. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterSlice(t testing.TB) *RequesterSlice {
 	mock := &RequesterSlice{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/RequesterSlice.go
+++ b/mocks/pkg/fixtures/RequesterSlice.go
@@ -39,6 +39,7 @@ func (_m *RequesterSlice) Get(path string) ([]string, error) {
 // NewRequesterSlice creates a new instance of RequesterSlice. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterSlice(t testing.TB) *RequesterSlice {
 	mock := &RequesterSlice{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/RequesterVariadic.go
+++ b/mocks/pkg/fixtures/RequesterVariadic.go
@@ -92,6 +92,7 @@ func (_m *RequesterVariadic) Sprintf(format string, a ...interface{}) string {
 // NewRequesterVariadic creates a new instance of RequesterVariadic. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterVariadic(t testing.TB) *RequesterVariadic {
 	mock := &RequesterVariadic{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/RequesterVariadic.go
+++ b/mocks/pkg/fixtures/RequesterVariadic.go
@@ -89,7 +89,7 @@ func (_m *RequesterVariadic) Sprintf(format string, a ...interface{}) string {
 	return r0
 }
 
-// NewRequesterVariadic creates a new instance of RequesterVariadic. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterVariadic creates a new instance of RequesterVariadic. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterVariadic(t testing.TB) *RequesterVariadic {
 	mock := &RequesterVariadic{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/RequesterVariadicOneArgument.go
+++ b/mocks/pkg/fixtures/RequesterVariadicOneArgument.go
@@ -71,7 +71,7 @@ func (_m *RequesterVariadicOneArgument) Sprintf(format string, a ...interface{})
 	return r0
 }
 
-// NewRequesterVariadicOneArgument creates a new instance of RequesterVariadicOneArgument. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterVariadicOneArgument creates a new instance of RequesterVariadicOneArgument. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterVariadicOneArgument(t testing.TB) *RequesterVariadicOneArgument {
 	mock := &RequesterVariadicOneArgument{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/RequesterVariadicOneArgument.go
+++ b/mocks/pkg/fixtures/RequesterVariadicOneArgument.go
@@ -74,6 +74,7 @@ func (_m *RequesterVariadicOneArgument) Sprintf(format string, a ...interface{})
 // NewRequesterVariadicOneArgument creates a new instance of RequesterVariadicOneArgument. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterVariadicOneArgument(t testing.TB) *RequesterVariadicOneArgument {
 	mock := &RequesterVariadicOneArgument{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/SendFunc.go
+++ b/mocks/pkg/fixtures/SendFunc.go
@@ -36,7 +36,7 @@ func (_m *SendFunc) Execute(ctx context.Context, data string) (int, error) {
 	return r0, r1
 }
 
-// NewSendFunc creates a new instance of SendFunc. It also registers a cleanup function to assert the mocks expectations.
+// NewSendFunc creates a new instance of SendFunc. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewSendFunc(t testing.TB) *SendFunc {
 	mock := &SendFunc{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/SendFunc.go
+++ b/mocks/pkg/fixtures/SendFunc.go
@@ -39,6 +39,7 @@ func (_m *SendFunc) Execute(ctx context.Context, data string) (int, error) {
 // NewSendFunc creates a new instance of SendFunc. It also registers a cleanup function to assert the mocks expectations.
 func NewSendFunc(t testing.TB) *SendFunc {
 	mock := &SendFunc{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/Sibling.go
+++ b/mocks/pkg/fixtures/Sibling.go
@@ -21,6 +21,7 @@ func (_m *Sibling) DoSomething() {
 // NewSibling creates a new instance of Sibling. It also registers a cleanup function to assert the mocks expectations.
 func NewSibling(t testing.TB) *Sibling {
 	mock := &Sibling{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/Sibling.go
+++ b/mocks/pkg/fixtures/Sibling.go
@@ -18,7 +18,7 @@ func (_m *Sibling) DoSomething() {
 	_m.Called()
 }
 
-// NewSibling creates a new instance of Sibling. It also registers a cleanup function to assert the mocks expectations.
+// NewSibling creates a new instance of Sibling. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewSibling(t testing.TB) *Sibling {
 	mock := &Sibling{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/UsesOtherPkgIface.go
+++ b/mocks/pkg/fixtures/UsesOtherPkgIface.go
@@ -19,7 +19,7 @@ func (_m *UsesOtherPkgIface) DoSomethingElse(obj test.Sibling) {
 	_m.Called(obj)
 }
 
-// NewUsesOtherPkgIface creates a new instance of UsesOtherPkgIface. It also registers a cleanup function to assert the mocks expectations.
+// NewUsesOtherPkgIface creates a new instance of UsesOtherPkgIface. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewUsesOtherPkgIface(t testing.TB) *UsesOtherPkgIface {
 	mock := &UsesOtherPkgIface{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/UsesOtherPkgIface.go
+++ b/mocks/pkg/fixtures/UsesOtherPkgIface.go
@@ -22,6 +22,7 @@ func (_m *UsesOtherPkgIface) DoSomethingElse(obj test.Sibling) {
 // NewUsesOtherPkgIface creates a new instance of UsesOtherPkgIface. It also registers a cleanup function to assert the mocks expectations.
 func NewUsesOtherPkgIface(t testing.TB) *UsesOtherPkgIface {
 	mock := &UsesOtherPkgIface{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/buildtag/comment/IfaceWithBuildTagInComment.go
+++ b/mocks/pkg/fixtures/buildtag/comment/IfaceWithBuildTagInComment.go
@@ -33,6 +33,7 @@ func (_m *IfaceWithBuildTagInComment) Sprintf(format string, a ...interface{}) s
 // NewIfaceWithBuildTagInComment creates a new instance of IfaceWithBuildTagInComment. It also registers a cleanup function to assert the mocks expectations.
 func NewIfaceWithBuildTagInComment(t testing.TB) *IfaceWithBuildTagInComment {
 	mock := &IfaceWithBuildTagInComment{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/buildtag/comment/IfaceWithBuildTagInComment.go
+++ b/mocks/pkg/fixtures/buildtag/comment/IfaceWithBuildTagInComment.go
@@ -30,7 +30,7 @@ func (_m *IfaceWithBuildTagInComment) Sprintf(format string, a ...interface{}) s
 	return r0
 }
 
-// NewIfaceWithBuildTagInComment creates a new instance of IfaceWithBuildTagInComment. It also registers a cleanup function to assert the mocks expectations.
+// NewIfaceWithBuildTagInComment creates a new instance of IfaceWithBuildTagInComment. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewIfaceWithBuildTagInComment(t testing.TB) *IfaceWithBuildTagInComment {
 	mock := &IfaceWithBuildTagInComment{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/buildtag/filename/IfaceWithBuildTagInFilename.go
+++ b/mocks/pkg/fixtures/buildtag/filename/IfaceWithBuildTagInFilename.go
@@ -33,6 +33,7 @@ func (_m *IfaceWithBuildTagInFilename) Sprintf(format string, a ...interface{}) 
 // NewIfaceWithBuildTagInFilename creates a new instance of IfaceWithBuildTagInFilename. It also registers a cleanup function to assert the mocks expectations.
 func NewIfaceWithBuildTagInFilename(t testing.TB) *IfaceWithBuildTagInFilename {
 	mock := &IfaceWithBuildTagInFilename{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/buildtag/filename/IfaceWithBuildTagInFilename.go
+++ b/mocks/pkg/fixtures/buildtag/filename/IfaceWithBuildTagInFilename.go
@@ -30,7 +30,7 @@ func (_m *IfaceWithBuildTagInFilename) Sprintf(format string, a ...interface{}) 
 	return r0
 }
 
-// NewIfaceWithBuildTagInFilename creates a new instance of IfaceWithBuildTagInFilename. It also registers a cleanup function to assert the mocks expectations.
+// NewIfaceWithBuildTagInFilename creates a new instance of IfaceWithBuildTagInFilename. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewIfaceWithBuildTagInFilename(t testing.TB) *IfaceWithBuildTagInFilename {
 	mock := &IfaceWithBuildTagInFilename{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/example_project/Root.go
+++ b/mocks/pkg/fixtures/example_project/Root.go
@@ -42,7 +42,7 @@ func (_m *Root) TakesBaz(_a0 *foo.Baz) {
 	_m.Called(_a0)
 }
 
-// NewRoot creates a new instance of Root. It also registers a cleanup function to assert the mocks expectations.
+// NewRoot creates a new instance of Root. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRoot(t testing.TB) *Root {
 	mock := &Root{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/example_project/Root.go
+++ b/mocks/pkg/fixtures/example_project/Root.go
@@ -45,6 +45,7 @@ func (_m *Root) TakesBaz(_a0 *foo.Baz) {
 // NewRoot creates a new instance of Root. It also registers a cleanup function to assert the mocks expectations.
 func NewRoot(t testing.TB) *Root {
 	mock := &Root{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/example_project/foo/Foo.go
+++ b/mocks/pkg/fixtures/example_project/foo/Foo.go
@@ -54,6 +54,7 @@ func (_m *Foo) GetBaz() (*foo.Baz, error) {
 // NewFoo creates a new instance of Foo. It also registers a cleanup function to assert the mocks expectations.
 func NewFoo(t testing.TB) *Foo {
 	mock := &Foo{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/fixtures/example_project/foo/Foo.go
+++ b/mocks/pkg/fixtures/example_project/foo/Foo.go
@@ -51,7 +51,7 @@ func (_m *Foo) GetBaz() (*foo.Baz, error) {
 	return r0, r1
 }
 
-// NewFoo creates a new instance of Foo. It also registers a cleanup function to assert the mocks expectations.
+// NewFoo creates a new instance of Foo. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewFoo(t testing.TB) *Foo {
 	mock := &Foo{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/requester_unexported.go
+++ b/mocks/pkg/fixtures/requester_unexported.go
@@ -18,7 +18,7 @@ func (_m *requester_unexported) Get() {
 	_m.Called()
 }
 
-// newRequester_unexported creates a new instance of requester_unexported. It also registers a cleanup function to assert the mocks expectations.
+// newRequester_unexported creates a new instance of requester_unexported. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func newRequester_unexported(t testing.TB) *requester_unexported {
 	mock := &requester_unexported{}
 	mock.Mock.Test(t)

--- a/mocks/pkg/fixtures/requester_unexported.go
+++ b/mocks/pkg/fixtures/requester_unexported.go
@@ -21,6 +21,7 @@ func (_m *requester_unexported) Get() {
 // newRequester_unexported creates a new instance of requester_unexported. It also registers a cleanup function to assert the mocks expectations.
 func newRequester_unexported(t testing.TB) *requester_unexported {
 	mock := &requester_unexported{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/pkg/namer.go
+++ b/mocks/pkg/namer.go
@@ -27,7 +27,7 @@ func (_m *namer) Name() string {
 	return r0
 }
 
-// newNamer creates a new instance of namer. It also registers a cleanup function to assert the mocks expectations.
+// newNamer creates a new instance of namer. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func newNamer(t testing.TB) *namer {
 	mock := &namer{}
 

--- a/pkg/fixtures/mocks/expecter.go
+++ b/pkg/fixtures/mocks/expecter.go
@@ -234,6 +234,7 @@ func (_c *ExpecterTest_VariadicMany_Call) Return(_a0 error) *ExpecterTest_Variad
 // NewExpecterTest creates a new instance of ExpecterTest. It also registers a cleanup function to assert the mocks expectations.
 func NewExpecterTest(t testing.TB) *ExpecterTest {
 	mock := &ExpecterTest{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/pkg/fixtures/mocks/expecter.go
+++ b/pkg/fixtures/mocks/expecter.go
@@ -231,7 +231,7 @@ func (_c *ExpecterTest_VariadicMany_Call) Return(_a0 error) *ExpecterTest_Variad
 	return _c
 }
 
-// NewExpecterTest creates a new instance of ExpecterTest. It also registers a cleanup function to assert the mocks expectations.
+// NewExpecterTest creates a new instance of ExpecterTest. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewExpecterTest(t testing.TB) *ExpecterTest {
 	mock := &ExpecterTest{}
 	mock.Mock.Test(t)

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -708,6 +708,7 @@ func (g *Generator) generateConstructor() {
 // %[1]s creates a new instance of %[2]s. It also registers a cleanup function to assert the mocks expectations.
 func %[1]s(t testing.TB) *%[2]s {
 	mock := &%[2]s{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -705,7 +705,7 @@ func (_c *{{.CallStruct}}) Return({{range .Returns.Params}}{{.}},{{end}}) *{{.Ca
 
 func (g *Generator) generateConstructor() {
 	const constructor = `
-// %[1]s creates a new instance of %[2]s. It also registers a cleanup function to assert the mocks expectations.
+// %[1]s creates a new instance of %[2]s. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func %[1]s(t testing.TB) *%[2]s {
 	mock := &%[2]s{}
 	mock.Mock.Test(t)

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -152,7 +152,7 @@ func (_m *Requester) Get(path string) (string, error) {
 	return r0, r1
 }
 
-// NewRequester creates a new instance of Requester. It also registers a cleanup function to assert the mocks expectations.
+// NewRequester creates a new instance of Requester. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequester(t testing.TB) *Requester {
 	mock := &Requester{}
 	mock.Mock.Test(t)
@@ -223,7 +223,7 @@ func (_c *Requester_Get_Call) Return(_a0 string, _a1 error) *Requester_Get_Call 
 	return _c
 }
 
-// NewRequester creates a new instance of Requester. It also registers a cleanup function to assert the mocks expectations.
+// NewRequester creates a new instance of Requester. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequester(t testing.TB) *Requester {
 	mock := &Requester{}
 	mock.Mock.Test(t)
@@ -292,7 +292,7 @@ func (_m *SendFunc) Execute(ctx context.Context, data string) (int, error) {
 	return r0, r1
 }
 
-// NewSendFunc creates a new instance of SendFunc. It also registers a cleanup function to assert the mocks expectations.
+// NewSendFunc creates a new instance of SendFunc. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewSendFunc(t testing.TB) *SendFunc {
 	mock := &SendFunc{}
 	mock.Mock.Test(t)
@@ -325,7 +325,7 @@ func (_m *Requester2) Get(path string) error {
 	return r0
 }
 
-// NewRequester2 creates a new instance of Requester2. It also registers a cleanup function to assert the mocks expectations.
+// NewRequester2 creates a new instance of Requester2. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequester2(t testing.TB) *Requester2 {
 	mock := &Requester2{}
 	mock.Mock.Test(t)
@@ -358,7 +358,7 @@ func (_m *Requester3) Get() error {
 	return r0
 }
 
-// NewRequester3 creates a new instance of Requester3. It also registers a cleanup function to assert the mocks expectations.
+// NewRequester3 creates a new instance of Requester3. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequester3(t testing.TB) *Requester3 {
 	mock := &Requester3{}
 	mock.Mock.Test(t)
@@ -382,7 +382,7 @@ func (_m *Requester4) Get() {
 	_m.Called()
 }
 
-// NewRequester4 creates a new instance of Requester4. It also registers a cleanup function to assert the mocks expectations.
+// NewRequester4 creates a new instance of Requester4. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequester4(t testing.TB) *Requester4 {
 	mock := &Requester4{}
 	mock.Mock.Test(t)
@@ -406,7 +406,7 @@ func (_m *mockRequester_unexported) Get() {
 	_m.Called()
 }
 
-// newMockRequester_unexported creates a new instance of mockRequester_unexported. It also registers a cleanup function to assert the mocks expectations.
+// newMockRequester_unexported creates a new instance of mockRequester_unexported. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func newMockRequester_unexported(t testing.TB) *mockRequester_unexported {
 	mock := &mockRequester_unexported{}
 	mock.Mock.Test(t)
@@ -430,7 +430,7 @@ func (_m *Mockrequester_unexported) Get() {
 	_m.Called()
 }
 
-// NewMockrequester_unexported creates a new instance of Mockrequester_unexported. It also registers a cleanup function to assert the mocks expectations.
+// NewMockrequester_unexported creates a new instance of Mockrequester_unexported. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewMockrequester_unexported(t testing.TB) *Mockrequester_unexported {
 	mock := &Mockrequester_unexported{}
 	mock.Mock.Test(t)
@@ -473,7 +473,7 @@ func (_m *Requester_unexported) Get() {
 	_m.Called()
 }
 
-// NewRequester_unexported creates a new instance of Requester_unexported. It also registers a cleanup function to assert the mocks expectations.
+// NewRequester_unexported creates a new instance of Requester_unexported. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequester_unexported(t testing.TB) *Requester_unexported {
 	mock := &Requester_unexported{}
 	mock.Mock.Test(t)
@@ -622,7 +622,7 @@ func (_m *RequesterIface) Get() io.Reader {
 	return r0
 }
 
-// NewRequesterIface creates a new instance of RequesterIface. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterIface creates a new instance of RequesterIface. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterIface(t testing.TB) *RequesterIface {
 	mock := &RequesterIface{}
 	mock.Mock.Test(t)
@@ -664,7 +664,7 @@ func (_m *RequesterPtr) Get(path string) (*string, error) {
 	return r0, r1
 }
 
-// NewRequesterPtr creates a new instance of RequesterPtr. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterPtr creates a new instance of RequesterPtr. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterPtr(t testing.TB) *RequesterPtr {
 	mock := &RequesterPtr{}
 	mock.Mock.Test(t)
@@ -706,7 +706,7 @@ func (_m *RequesterSlice) Get(path string) ([]string, error) {
 	return r0, r1
 }
 
-// NewRequesterSlice creates a new instance of RequesterSlice. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterSlice creates a new instance of RequesterSlice. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterSlice(t testing.TB) *RequesterSlice {
 	mock := &RequesterSlice{}
 	mock.Mock.Test(t)
@@ -748,7 +748,7 @@ func (_m *RequesterArray) Get(path string) ([2]string, error) {
 	return r0, r1
 }
 
-// NewRequesterArray creates a new instance of RequesterArray. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterArray creates a new instance of RequesterArray. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterArray(t testing.TB) *RequesterArray {
 	mock := &RequesterArray{}
 	mock.Mock.Test(t)
@@ -788,7 +788,7 @@ func (_m *RequesterNS) Get(path string) (http.Response, error) {
 	return r0, r1
 }
 
-// NewRequesterNS creates a new instance of RequesterNS. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterNS creates a new instance of RequesterNS. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterNS(t testing.TB) *RequesterNS {
 	mock := &RequesterNS{}
 	mock.Mock.Test(t)
@@ -823,7 +823,7 @@ func (_m *RequesterArgSameAsImport) Get(_a0 string) *json.RawMessage {
 	return r0
 }
 
-// NewRequesterArgSameAsImport creates a new instance of RequesterArgSameAsImport. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterArgSameAsImport creates a new instance of RequesterArgSameAsImport. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterArgSameAsImport(t testing.TB) *RequesterArgSameAsImport {
 	mock := &RequesterArgSameAsImport{}
 	mock.Mock.Test(t)
@@ -858,7 +858,7 @@ func (_m *RequesterArgSameAsNamedImport) Get(_a0 string) *json.RawMessage {
 	return r0
 }
 
-// NewRequesterArgSameAsNamedImport creates a new instance of RequesterArgSameAsNamedImport. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterArgSameAsNamedImport creates a new instance of RequesterArgSameAsNamedImport. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterArgSameAsNamedImport(t testing.TB) *RequesterArgSameAsNamedImport {
 	mock := &RequesterArgSameAsNamedImport{}
 	mock.Mock.Test(t)
@@ -882,7 +882,7 @@ func (_m *RequesterArgSameAsPkg) Get(_a0 string) {
 	_m.Called(_a0)
 }
 
-// NewRequesterArgSameAsPkg creates a new instance of RequesterArgSameAsPkg. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterArgSameAsPkg creates a new instance of RequesterArgSameAsPkg. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterArgSameAsPkg(t testing.TB) *RequesterArgSameAsPkg {
 	mock := &RequesterArgSameAsPkg{}
 	mock.Mock.Test(t)
@@ -926,7 +926,7 @@ func (_m *KeyManager) GetKey(_a0 string, _a1 uint16) ([]byte, *test.Err) {
 	return r0, r1
 }
 
-// NewKeyManager creates a new instance of KeyManager. It also registers a cleanup function to assert the mocks expectations.
+// NewKeyManager creates a new instance of KeyManager. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewKeyManager(t testing.TB) *KeyManager {
 	mock := &KeyManager{}
 	mock.Mock.Test(t)
@@ -959,7 +959,7 @@ func (_m *RequesterElided) Get(path string, url string) error {
 	return r0
 }
 
-// NewRequesterElided creates a new instance of RequesterElided. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterElided creates a new instance of RequesterElided. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterElided(t testing.TB) *RequesterElided {
 	mock := &RequesterElided{}
 	mock.Mock.Test(t)
@@ -1013,7 +1013,7 @@ func (_m *RequesterReturnElided) Get(path string) (int, int, int, error) {
 	return r0, r1, r2, r3
 }
 
-// NewRequesterReturnElided creates a new instance of RequesterReturnElided. It also registers a cleanup function to assert the mocks expectations.
+// NewRequesterReturnElided creates a new instance of RequesterReturnElided. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequesterReturnElided(t testing.TB) *RequesterReturnElided {
 	mock := &RequesterReturnElided{}
 	mock.Mock.Test(t)
@@ -1192,7 +1192,7 @@ func (_m *Fooer) Foo(f func(string) string) error {
 	return r0
 }
 
-// NewFooer creates a new instance of Fooer. It also registers a cleanup function to assert the mocks expectations.
+// NewFooer creates a new instance of Fooer. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewFooer(t testing.TB) *Fooer {
 	mock := &Fooer{}
 	mock.Mock.Test(t)
@@ -1259,7 +1259,7 @@ func (_m *AsyncProducer) Whatever() chan bool {
 	return r0
 }
 
-// NewAsyncProducer creates a new instance of AsyncProducer. It also registers a cleanup function to assert the mocks expectations.
+// NewAsyncProducer creates a new instance of AsyncProducer. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewAsyncProducer(t testing.TB) *AsyncProducer {
 	mock := &AsyncProducer{}
 	mock.Mock.Test(t)
@@ -1299,7 +1299,7 @@ func (_m *MyReader) Read(p []byte) (int, error) {
 	return r0, r1
 }
 
-// NewMyReader creates a new instance of MyReader. It also registers a cleanup function to assert the mocks expectations.
+// NewMyReader creates a new instance of MyReader. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewMyReader(t testing.TB) *MyReader {
 	mock := &MyReader{}
 	mock.Mock.Test(t)
@@ -1355,7 +1355,7 @@ func (_m *ConsulLock) Unlock() error {
 	return r0
 }
 
-// NewConsulLock creates a new instance of ConsulLock. It also registers a cleanup function to assert the mocks expectations.
+// NewConsulLock creates a new instance of ConsulLock. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewConsulLock(t testing.TB) *ConsulLock {
 	mock := &ConsulLock{}
 	mock.Mock.Test(t)
@@ -1388,7 +1388,7 @@ func (_m *Blank) Create(x interface{}) error {
 	return r0
 }
 
-// NewBlank creates a new instance of Blank. It also registers a cleanup function to assert the mocks expectations.
+// NewBlank creates a new instance of Blank. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewBlank(t testing.TB) *Blank {
 	mock := &Blank{}
 	mock.Mock.Test(t)
@@ -1421,7 +1421,7 @@ func (_m *MapFunc) Get(m map[string]func(string) string) error {
 	return r0
 }
 
-// NewMapFunc creates a new instance of MapFunc. It also registers a cleanup function to assert the mocks expectations.
+// NewMapFunc creates a new instance of MapFunc. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewMapFunc(t testing.TB) *MapFunc {
 	mock := &MapFunc{}
 	mock.Mock.Test(t)
@@ -1445,7 +1445,7 @@ func (_m *UsesOtherPkgIface) DoSomethingElse(obj test.Sibling) {
 	_m.Called(obj)
 }
 
-// NewUsesOtherPkgIface creates a new instance of UsesOtherPkgIface. It also registers a cleanup function to assert the mocks expectations.
+// NewUsesOtherPkgIface creates a new instance of UsesOtherPkgIface. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewUsesOtherPkgIface(t testing.TB) *UsesOtherPkgIface {
 	mock := &UsesOtherPkgIface{}
 	mock.Mock.Test(t)
@@ -1469,7 +1469,7 @@ func (_m *MockUsesOtherPkgIface) DoSomethingElse(obj Sibling) {
 	_m.Called(obj)
 }
 
-// NewMockUsesOtherPkgIface creates a new instance of MockUsesOtherPkgIface. It also registers a cleanup function to assert the mocks expectations.
+// NewMockUsesOtherPkgIface creates a new instance of MockUsesOtherPkgIface. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewMockUsesOtherPkgIface(t testing.TB) *MockUsesOtherPkgIface {
 	mock := &MockUsesOtherPkgIface{}
 	mock.Mock.Test(t)
@@ -1518,7 +1518,7 @@ func (_m *Example) B(_a0 string) fixtureshttp.MyStruct {
 	return r0
 }
 
-// NewExample creates a new instance of Example. It also registers a cleanup function to assert the mocks expectations.
+// NewExample creates a new instance of Example. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewExample(t testing.TB) *Example {
 	mock := &Example{}
 	mock.Mock.Test(t)
@@ -1558,7 +1558,7 @@ func (_m *MapToInterface) Foo(arg1 ...map[string]interface{}) {
 	_m.Called(_ca...)
 }
 
-// NewMapToInterface creates a new instance of MapToInterface. It also registers a cleanup function to assert the mocks expectations.
+// NewMapToInterface creates a new instance of MapToInterface. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewMapToInterface(t testing.TB) *MapToInterface {
 	mock := &MapToInterface{}
 	mock.Mock.Test(t)
@@ -1592,7 +1592,7 @@ func (_m *FuncArgsCollision) Foo(ret interface{}) error {
 	return r0
 }
 
-// NewFuncArgsCollision creates a new instance of FuncArgsCollision. It also registers a cleanup function to assert the mocks expectations.
+// NewFuncArgsCollision creates a new instance of FuncArgsCollision. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewFuncArgsCollision(t testing.TB) *FuncArgsCollision {
 	mock := &FuncArgsCollision{}
 	mock.Mock.Test(t)
@@ -1646,7 +1646,7 @@ func (_m *ImportsSameAsPackage) C(_a0 fixtures.C) {
 	_m.Called(_a0)
 }
 
-// NewImportsSameAsPackage creates a new instance of ImportsSameAsPackage. It also registers a cleanup function to assert the mocks expectations.
+// NewImportsSameAsPackage creates a new instance of ImportsSameAsPackage. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewImportsSameAsPackage(t testing.TB) *ImportsSameAsPackage {
 	mock := &ImportsSameAsPackage{}
 	mock.Mock.Test(t)
@@ -1718,7 +1718,7 @@ func (_m *A) Call() (test.B, error) {
 	return r0, r1
 }
 
-// NewA creates a new instance of A. It also registers a cleanup function to assert the mocks expectations.
+// NewA creates a new instance of A. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewA(t testing.TB) *A {
 	mock := &A{}
 	mock.Mock.Test(t)
@@ -1751,7 +1751,7 @@ func (_m *Requester2OverrideName) Get(path string) error {
 	return r0
 }
 
-// NewRequester2OverrideName creates a new instance of Requester2OverrideName. It also registers a cleanup function to assert the mocks expectations.
+// NewRequester2OverrideName creates a new instance of Requester2OverrideName. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewRequester2OverrideName(t testing.TB) *Requester2OverrideName {
 	mock := &Requester2OverrideName{}
 	mock.Mock.Test(t)

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -155,6 +155,7 @@ func (_m *Requester) Get(path string) (string, error) {
 // NewRequester creates a new instance of Requester. It also registers a cleanup function to assert the mocks expectations.
 func NewRequester(t testing.TB) *Requester {
 	mock := &Requester{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -225,6 +226,7 @@ func (_c *Requester_Get_Call) Return(_a0 string, _a1 error) *Requester_Get_Call 
 // NewRequester creates a new instance of Requester. It also registers a cleanup function to assert the mocks expectations.
 func NewRequester(t testing.TB) *Requester {
 	mock := &Requester{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -293,6 +295,7 @@ func (_m *SendFunc) Execute(ctx context.Context, data string) (int, error) {
 // NewSendFunc creates a new instance of SendFunc. It also registers a cleanup function to assert the mocks expectations.
 func NewSendFunc(t testing.TB) *SendFunc {
 	mock := &SendFunc{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -325,6 +328,7 @@ func (_m *Requester2) Get(path string) error {
 // NewRequester2 creates a new instance of Requester2. It also registers a cleanup function to assert the mocks expectations.
 func NewRequester2(t testing.TB) *Requester2 {
 	mock := &Requester2{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -357,6 +361,7 @@ func (_m *Requester3) Get() error {
 // NewRequester3 creates a new instance of Requester3. It also registers a cleanup function to assert the mocks expectations.
 func NewRequester3(t testing.TB) *Requester3 {
 	mock := &Requester3{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -380,6 +385,7 @@ func (_m *Requester4) Get() {
 // NewRequester4 creates a new instance of Requester4. It also registers a cleanup function to assert the mocks expectations.
 func NewRequester4(t testing.TB) *Requester4 {
 	mock := &Requester4{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -403,6 +409,7 @@ func (_m *mockRequester_unexported) Get() {
 // newMockRequester_unexported creates a new instance of mockRequester_unexported. It also registers a cleanup function to assert the mocks expectations.
 func newMockRequester_unexported(t testing.TB) *mockRequester_unexported {
 	mock := &mockRequester_unexported{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -426,6 +433,7 @@ func (_m *Mockrequester_unexported) Get() {
 // NewMockrequester_unexported creates a new instance of Mockrequester_unexported. It also registers a cleanup function to assert the mocks expectations.
 func NewMockrequester_unexported(t testing.TB) *Mockrequester_unexported {
 	mock := &Mockrequester_unexported{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -468,6 +476,7 @@ func (_m *Requester_unexported) Get() {
 // NewRequester_unexported creates a new instance of Requester_unexported. It also registers a cleanup function to assert the mocks expectations.
 func NewRequester_unexported(t testing.TB) *Requester_unexported {
 	mock := &Requester_unexported{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -616,6 +625,7 @@ func (_m *RequesterIface) Get() io.Reader {
 // NewRequesterIface creates a new instance of RequesterIface. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterIface(t testing.TB) *RequesterIface {
 	mock := &RequesterIface{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -657,6 +667,7 @@ func (_m *RequesterPtr) Get(path string) (*string, error) {
 // NewRequesterPtr creates a new instance of RequesterPtr. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterPtr(t testing.TB) *RequesterPtr {
 	mock := &RequesterPtr{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -698,6 +709,7 @@ func (_m *RequesterSlice) Get(path string) ([]string, error) {
 // NewRequesterSlice creates a new instance of RequesterSlice. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterSlice(t testing.TB) *RequesterSlice {
 	mock := &RequesterSlice{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -739,6 +751,7 @@ func (_m *RequesterArray) Get(path string) ([2]string, error) {
 // NewRequesterArray creates a new instance of RequesterArray. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterArray(t testing.TB) *RequesterArray {
 	mock := &RequesterArray{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -778,6 +791,7 @@ func (_m *RequesterNS) Get(path string) (http.Response, error) {
 // NewRequesterNS creates a new instance of RequesterNS. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterNS(t testing.TB) *RequesterNS {
 	mock := &RequesterNS{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -812,6 +826,7 @@ func (_m *RequesterArgSameAsImport) Get(_a0 string) *json.RawMessage {
 // NewRequesterArgSameAsImport creates a new instance of RequesterArgSameAsImport. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterArgSameAsImport(t testing.TB) *RequesterArgSameAsImport {
 	mock := &RequesterArgSameAsImport{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -846,6 +861,7 @@ func (_m *RequesterArgSameAsNamedImport) Get(_a0 string) *json.RawMessage {
 // NewRequesterArgSameAsNamedImport creates a new instance of RequesterArgSameAsNamedImport. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterArgSameAsNamedImport(t testing.TB) *RequesterArgSameAsNamedImport {
 	mock := &RequesterArgSameAsNamedImport{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -869,6 +885,7 @@ func (_m *RequesterArgSameAsPkg) Get(_a0 string) {
 // NewRequesterArgSameAsPkg creates a new instance of RequesterArgSameAsPkg. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterArgSameAsPkg(t testing.TB) *RequesterArgSameAsPkg {
 	mock := &RequesterArgSameAsPkg{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -912,6 +929,7 @@ func (_m *KeyManager) GetKey(_a0 string, _a1 uint16) ([]byte, *test.Err) {
 // NewKeyManager creates a new instance of KeyManager. It also registers a cleanup function to assert the mocks expectations.
 func NewKeyManager(t testing.TB) *KeyManager {
 	mock := &KeyManager{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -944,6 +962,7 @@ func (_m *RequesterElided) Get(path string, url string) error {
 // NewRequesterElided creates a new instance of RequesterElided. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterElided(t testing.TB) *RequesterElided {
 	mock := &RequesterElided{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -997,6 +1016,7 @@ func (_m *RequesterReturnElided) Get(path string) (int, int, int, error) {
 // NewRequesterReturnElided creates a new instance of RequesterReturnElided. It also registers a cleanup function to assert the mocks expectations.
 func NewRequesterReturnElided(t testing.TB) *RequesterReturnElided {
 	mock := &RequesterReturnElided{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -1175,6 +1195,7 @@ func (_m *Fooer) Foo(f func(string) string) error {
 // NewFooer creates a new instance of Fooer. It also registers a cleanup function to assert the mocks expectations.
 func NewFooer(t testing.TB) *Fooer {
 	mock := &Fooer{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -1241,6 +1262,7 @@ func (_m *AsyncProducer) Whatever() chan bool {
 // NewAsyncProducer creates a new instance of AsyncProducer. It also registers a cleanup function to assert the mocks expectations.
 func NewAsyncProducer(t testing.TB) *AsyncProducer {
 	mock := &AsyncProducer{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -1280,6 +1302,7 @@ func (_m *MyReader) Read(p []byte) (int, error) {
 // NewMyReader creates a new instance of MyReader. It also registers a cleanup function to assert the mocks expectations.
 func NewMyReader(t testing.TB) *MyReader {
 	mock := &MyReader{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -1335,6 +1358,7 @@ func (_m *ConsulLock) Unlock() error {
 // NewConsulLock creates a new instance of ConsulLock. It also registers a cleanup function to assert the mocks expectations.
 func NewConsulLock(t testing.TB) *ConsulLock {
 	mock := &ConsulLock{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -1367,6 +1391,7 @@ func (_m *Blank) Create(x interface{}) error {
 // NewBlank creates a new instance of Blank. It also registers a cleanup function to assert the mocks expectations.
 func NewBlank(t testing.TB) *Blank {
 	mock := &Blank{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -1399,6 +1424,7 @@ func (_m *MapFunc) Get(m map[string]func(string) string) error {
 // NewMapFunc creates a new instance of MapFunc. It also registers a cleanup function to assert the mocks expectations.
 func NewMapFunc(t testing.TB) *MapFunc {
 	mock := &MapFunc{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -1422,6 +1448,7 @@ func (_m *UsesOtherPkgIface) DoSomethingElse(obj test.Sibling) {
 // NewUsesOtherPkgIface creates a new instance of UsesOtherPkgIface. It also registers a cleanup function to assert the mocks expectations.
 func NewUsesOtherPkgIface(t testing.TB) *UsesOtherPkgIface {
 	mock := &UsesOtherPkgIface{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -1445,6 +1472,7 @@ func (_m *MockUsesOtherPkgIface) DoSomethingElse(obj Sibling) {
 // NewMockUsesOtherPkgIface creates a new instance of MockUsesOtherPkgIface. It also registers a cleanup function to assert the mocks expectations.
 func NewMockUsesOtherPkgIface(t testing.TB) *MockUsesOtherPkgIface {
 	mock := &MockUsesOtherPkgIface{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -1493,6 +1521,7 @@ func (_m *Example) B(_a0 string) fixtureshttp.MyStruct {
 // NewExample creates a new instance of Example. It also registers a cleanup function to assert the mocks expectations.
 func NewExample(t testing.TB) *Example {
 	mock := &Example{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -1532,6 +1561,7 @@ func (_m *MapToInterface) Foo(arg1 ...map[string]interface{}) {
 // NewMapToInterface creates a new instance of MapToInterface. It also registers a cleanup function to assert the mocks expectations.
 func NewMapToInterface(t testing.TB) *MapToInterface {
 	mock := &MapToInterface{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -1565,6 +1595,7 @@ func (_m *FuncArgsCollision) Foo(ret interface{}) error {
 // NewFuncArgsCollision creates a new instance of FuncArgsCollision. It also registers a cleanup function to assert the mocks expectations.
 func NewFuncArgsCollision(t testing.TB) *FuncArgsCollision {
 	mock := &FuncArgsCollision{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -1618,6 +1649,7 @@ func (_m *ImportsSameAsPackage) C(_a0 fixtures.C) {
 // NewImportsSameAsPackage creates a new instance of ImportsSameAsPackage. It also registers a cleanup function to assert the mocks expectations.
 func NewImportsSameAsPackage(t testing.TB) *ImportsSameAsPackage {
 	mock := &ImportsSameAsPackage{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -1689,6 +1721,7 @@ func (_m *A) Call() (test.B, error) {
 // NewA creates a new instance of A. It also registers a cleanup function to assert the mocks expectations.
 func NewA(t testing.TB) *A {
 	mock := &A{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 
@@ -1721,6 +1754,7 @@ func (_m *Requester2OverrideName) Get(path string) error {
 // NewRequester2OverrideName creates a new instance of Requester2OverrideName. It also registers a cleanup function to assert the mocks expectations.
 func NewRequester2OverrideName(t testing.TB) *Requester2OverrideName {
 	mock := &Requester2OverrideName{}
+	mock.Mock.Test(t)
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 


### PR DESCRIPTION
Description
-------------

Following the recent addition of constructors for mocks by @grongor in https://github.com/vektra/mockery/pull/406, this PR is a suggestion to also register the `testing.TB` interface on `mock.Mock`.

This is a feature in testify's mock.Mock that makes it so that whenever a mock is not matched, the whole suite does not panic, but instead makes the test fails. It is in some way breaking in the sense that the behaviour that some might be used to (ie. stop the world panic) will not be the same, but while we added a cleanup function I think this is desirable.

This is of course debatable :smiley:

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [x] 1.16
- [ ] 1.17
- [x] 1.18

How Has This Been Tested?
---------------------------

Added generation to related files and tested locally with `go test ./...`

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

