### PR TITLE
Support directory exclusion when generating mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Table of Contents
 - [Expecter Interfaces](#expecter-interfaces)
 - [Mock constructors](#mock-constructors)
 - [Extended Flag Descriptions](#extended-flag-descriptions)
+- [Excluding Directories](#excluding-directories)
 - [Mocking interfaces in `main`](#mocking-interfaces-in-main)
 - [Configuration](#configuration)
   * [Example](#example)
@@ -366,6 +367,11 @@ The following descriptions provide additional elaboration on a few common parame
 | `--print` | Use `mockery --print` to have the resulting code printed out instead of written to disk. |
 | `--exported` | Use `mockery --exported` to generate public mocks for private interfaces. |
 | `--with-expecter` | Use `mockery --with-expecter` to generate `EXPECT()` methods for your mocks. This is the preferred way to setup your mocks. |
+
+Excluding Directories
+---------------------
+
+Directories can be excluded from mock generation by placing a file `.mockery_skip` inside them. Mocks will not be generated for any types present in a directory containing such a file nor for any in its sub-directories.
 
 Mocking interfaces in `main`
 ----------------------------


### PR DESCRIPTION
Description
-------------

Sometimes mocks are wanted for the majority of a project, but specific directories are to be excluded (e.g. `internal`).

This adds support for excluding a directory and its sub-directories from mock generation by placing a file named `.mockery_skip` inside it.

- Fixes #[395](https://github.com/vektra/mockery/issues/395)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [X] 1.16
- [ ] 1.17
- [ ] 1.18

How Has This Been Tested?
---------------------------

New test added that adds a `.mockery_skip` file into the the fixtures directory and then runs the same walker test as `TestWalkerHere` but asserting that the generated mocks were the reduced set.

Checklist
-----------

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

