### PR TITLE
fix: address module imports that end with .go

### DIFF
--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -194,7 +194,7 @@ func (g *Generator) getLocalizedPath(ctx context.Context, path string) string {
 	log := zerolog.Ctx(ctx).With().Str(logging.LogKeyPath, path).Logger()
 	ctx = log.WithContext(ctx)
 
-	if strings.HasSuffix(path, ".go") {
+	if strings.HasSuffix(path, ".go") && strings.Contains(path, "vendor"+string(filepath.Separator)) {
 		path, _ = filepath.Split(path)
 	}
 	if localized, ok := g.localizationCache[path]; ok {

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -2433,6 +2433,26 @@ func NewMockRequesterGenerics[TAny interface{}, TComparable comparable, TSigned 
 	s.checkGeneration("generic.go", "RequesterGenerics", true, "", expected)
 }
 
+func (s *GeneratorSuite) TestGetLocalizedPathVendored() {
+	generator := s.getGenerator(testFile, "Requester", false, "")
+	result := generator.getLocalizedPath(context.Background(), "vendor/github.com/nats-io/nats.go/js.go")
+
+	s.Equal(
+		"github.com/nats-io/nats.go", result,
+		"The generator produced unexpected output.",
+	)
+}
+
+func (s *GeneratorSuite) TestGetLocalizedPathModule() {
+	generator := s.getGenerator(testFile, "Requester", false, "")
+	result := generator.getLocalizedPath(context.Background(), "github.com/nats-io/nats.go")
+
+	s.Equal(
+		"github.com/nats-io/nats.go", result,
+		"The generator produced unexpected output.",
+	)
+}
+
 func TestGeneratorSuite(t *testing.T) {
 	generatorSuite := new(GeneratorSuite)
 	suite.Run(t, generatorSuite)


### PR DESCRIPTION
Description
-------------

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

- Fixes #481 #249 #419

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [x ] 1.18

How Has This Been Tested?
---------------------------

See `TestGetLocalizedPathVendored` and `TestGetLocalizedPathModule` in `generator_test.go`

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

