### PR TITLE
Replace deprecated ioutil pkg with os & io

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -11,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -99,7 +98,7 @@ func printStackTrace(e error) {
 // Execute executes the cobra CLI workflow
 func Execute() {
 	if err := NewRootCmd().Execute(); err != nil {
-		//printStackTrace(err)
+		// printStackTrace(err)
 		os.Exit(1)
 	}
 }
@@ -247,7 +246,7 @@ func (r *RootApp) Run() error {
 
 	var boilerplate string
 	if r.Config.BoilerplateFile != "" {
-		data, err := ioutil.ReadFile(r.Config.BoilerplateFile)
+		data, err := os.ReadFile(r.Config.BoilerplateFile)
 		if err != nil {
 			log.Fatal().Msgf("Failed to read boilerplate file %s: %v", r.Config.BoilerplateFile, err)
 		}

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"go/format"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1359,7 +1359,7 @@ func NewRequesterReturnElided(t mockConstructorTestingTNewRequesterReturnElided)
 }
 
 func (s *GeneratorSuite) TestGeneratorVariadicArgs() {
-	expectedBytes, err := ioutil.ReadFile(getMocksPath("RequesterVariadic.go"))
+	expectedBytes, err := os.ReadFile(getMocksPath("RequesterVariadic.go"))
 	s.NoError(err)
 	expected := string(expectedBytes)
 	expected = expected[strings.Index(expected, "// RequesterVariadic is"):]
@@ -1367,7 +1367,7 @@ func (s *GeneratorSuite) TestGeneratorVariadicArgs() {
 }
 
 func (s *GeneratorSuite) TestGeneratorVariadicArgsAsOneArg() {
-	expectedBytes, err := ioutil.ReadFile(getMocksPath("RequesterVariadicOneArgument.go"))
+	expectedBytes, err := os.ReadFile(getMocksPath("RequesterVariadicOneArgument.go"))
 	s.NoError(err)
 	expected := string(expectedBytes)
 	expected = expected[strings.Index(expected, "// RequesterVariadicOneArgument is"):]

--- a/pkg/parse.go
+++ b/pkg/parse.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -73,7 +73,7 @@ func (p *Parser) Parse(ctx context.Context, path string) error {
 
 	dir := filepath.Dir(path)
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return err
 	}

--- a/pkg/walker.go
+++ b/pkg/walker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -70,7 +69,7 @@ func (w *Walker) doWalk(ctx context.Context, p *Parser, dir string, visitor Walk
 	log := zerolog.Ctx(ctx)
 	ctx = log.WithContext(ctx)
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Description
-------------
As of Go 1.16, the same functionality is now provided by package io or
package os, and those implementations should be preferred in new code.

So replacing all usage of ioutil pkg with io & os.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Others

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [x] 1.16
- [x] 1.17
- [x] 1.18

How Has This Been Tested?
---------------------------
Since the change is just replacing ioutil pkg with os & io pkg, testing was done with existing test cases to ensure no regression issues occur.

Checklist
-----------
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not needed)
- [x] New and existing unit tests pass locally with my changes

