### PR TITLE
Add replace for internal path

### DIFF
--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog"
+
 	"github.com/vektra/mockery/v2/pkg/config"
 	"github.com/vektra/mockery/v2/pkg/logging"
 )
@@ -56,6 +57,9 @@ func (p *FileOutputStreamProvider) GetWriter(ctx context.Context, iface *Interfa
 		relativePath := strings.TrimPrefix(
 			filepath.Join(filepath.Dir(iface.FileName), p.filename(caseName)),
 			absOriginalDir)
+
+		relativePath = strings.Replace(relativePath, "/internal/", "/_internal/", -1)
+
 		path = filepath.Join(p.BaseDir, relativePath)
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 			return nil, err, func() error { return nil }

--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -58,7 +58,8 @@ func (p *FileOutputStreamProvider) GetWriter(ctx context.Context, iface *Interfa
 			filepath.Join(filepath.Dir(iface.FileName), p.filename(caseName)),
 			absOriginalDir)
 
-		relativePath = strings.Replace(relativePath, "/internal/", "/_internal/", -1)
+		// as it's not possible to import from internal path, we have to replace it in mocks when KepTree is used
+		relativePath = strings.Replace(relativePath, "/internal/", "/internal_/", -1)
 
 		path = filepath.Join(p.BaseDir, relativePath)
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {


### PR DESCRIPTION
Description
-------------

Replace `internal` path with prefixed `_` for `--keeptree`

- Fixes #508 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [x] 1.18

How Has This Been Tested?
---------------------------

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

