### PR TITLE
update to go 1.19

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@ Version of Golang used when building/testing:
 - [ ] 1.16
 - [ ] 1.17
 - [ ] 1.18
+- [ ] 1.19
 
 How Has This Been Tested?
 ---------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-latest, ubuntu-latest]
-        go_vers: [1.18]
+        go_vers: [1.19]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as builder
+FROM golang:1.19-alpine as builder
 
 COPY mockery /usr/local/bin
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vektra/mockery/v2
 
-go 1.18
+go 1.19
 
 require (
 	github.com/mitchellh/go-homedir v1.1.0

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -211,7 +211,7 @@ type Requester_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
-//  - path string
+//   - path string
 func (_e *Requester_Expecter) Get(path interface{}) *Requester_Get_Call {
 	return &Requester_Get_Call{Call: _e.mock.On("Get", path)}
 }
@@ -294,8 +294,8 @@ type Expecter_ManyArgsReturns_Call struct {
 }
 
 // ManyArgsReturns is a helper method to define mock.On call
-//  - str string
-//  - i int
+//   - str string
+//   - i int
 func (_e *Expecter_Expecter) ManyArgsReturns(str interface{}, i interface{}) *Expecter_ManyArgsReturns_Call {
 	return &Expecter_ManyArgsReturns_Call{Call: _e.mock.On("ManyArgsReturns", str, i)}
 }
@@ -359,7 +359,7 @@ type Expecter_NoReturn_Call struct {
 }
 
 // NoReturn is a helper method to define mock.On call
-//  - str string
+//   - str string
 func (_e *Expecter_Expecter) NoReturn(str interface{}) *Expecter_NoReturn_Call {
 	return &Expecter_NoReturn_Call{Call: _e.mock.On("NoReturn", str)}
 }
@@ -402,7 +402,7 @@ type Expecter_Variadic_Call struct {
 }
 
 // Variadic is a helper method to define mock.On call
-//  - ints ...int
+//   - ints ...int
 func (_e *Expecter_Expecter) Variadic(ints ...interface{}) *Expecter_Variadic_Call {
 	return &Expecter_Variadic_Call{Call: _e.mock.On("Variadic",
 		append([]interface{}{}, ints...)...)}
@@ -449,9 +449,9 @@ type Expecter_VariadicMany_Call struct {
 }
 
 // VariadicMany is a helper method to define mock.On call
-//  - i int
-//  - a string
-//  - intfs ...interface{}
+//   - i int
+//   - a string
+//   - intfs ...interface{}
 func (_e *Expecter_Expecter) VariadicMany(i interface{}, a interface{}, intfs ...interface{}) *Expecter_VariadicMany_Call {
 	return &Expecter_VariadicMany_Call{Call: _e.mock.On("VariadicMany",
 		append([]interface{}{i, a}, intfs...)...)}
@@ -2397,7 +2397,7 @@ type RequesterGenerics_GenericAnonymousStructs_Call[TAny interface{}, TComparabl
 }
 
 // GenericAnonymousStructs is a helper method to define mock.On call
-//  - _a0 struct{Type1 TExternalIntf}
+//   - _a0 struct{Type1 TExternalIntf}
 func (_e *RequesterGenerics_Expecter[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]) GenericAnonymousStructs(_a0 interface{}) *RequesterGenerics_GenericAnonymousStructs_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
 	return &RequesterGenerics_GenericAnonymousStructs_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]{Call: _e.mock.On("GenericAnonymousStructs", _a0)}
 }
@@ -2446,8 +2446,8 @@ type RequesterGenerics_GenericArguments_Call[TAny interface{}, TComparable compa
 }
 
 // GenericArguments is a helper method to define mock.On call
-//  - _a0 TAny
-//  - _a1 TComparable
+//   - _a0 TAny
+//   - _a1 TComparable
 func (_e *RequesterGenerics_Expecter[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]) GenericArguments(_a0 interface{}, _a1 interface{}) *RequesterGenerics_GenericArguments_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
 	return &RequesterGenerics_GenericArguments_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]{Call: _e.mock.On("GenericArguments", _a0, _a1)}
 }
@@ -2487,7 +2487,7 @@ type RequesterGenerics_GenericStructs_Call[TAny interface{}, TComparable compara
 }
 
 // GenericStructs is a helper method to define mock.On call
-//  - _a0 test.GenericType[TAny,TIntf]
+//   - _a0 test.GenericType[TAny,TIntf]
 func (_e *RequesterGenerics_Expecter[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]) GenericStructs(_a0 interface{}) *RequesterGenerics_GenericStructs_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
 	return &RequesterGenerics_GenericStructs_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]{Call: _e.mock.On("GenericStructs", _a0)}
 }


### PR DESCRIPTION
Description
-------------

I updated the go version from 1.18 to 1.19. This resulted in broken tests, which I've also fixed. The generated code seems to differ a bit with what is was on 1.18. Not sure why that is, but according to #502 it seems that more people have this issue.

- Fixes #502 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.19

How Has This Been Tested?
---------------------------

`go test ./...`

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

