### PR TITLE
Add multiarch container builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -17,6 +20,12 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.18
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,13 +34,10 @@ snapshot:
 changelog:
     sort: asc
 dockers:
-  - goos: linux
+  - image_templates: ["vektra/mockery:{{ .Tag }}-amd64"]
     goarch: amd64
-    image_templates:
-      - 'vektra/mockery:{{ .Tag }}'
-      - 'vektra/mockery:v{{ .Major }}'
-      - 'vektra/mockery:v{{ .Major }}.{{ .Minor }}'
-      - 'vektra/mockery:latest'
+    dockerfile: Dockerfile
+    use: buildx
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -48,6 +45,36 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/amd64"
+  - image_templates: ["vektra/mockery:{{ .Tag }}-arm64"]
+    goarch: arm64
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/arm64"
+docker_manifests:
+  - name_template: vektra/mockery:{{ .Tag }}
+    image_templates:
+      - vektra/mockery:{{ .Tag }}-amd64
+      - vektra/mockery:{{ .Tag }}-arm64
+  - name_template: vektra/mockery:v{{ .Major }}
+    image_templates:
+      - vektra/mockery:{{ .Tag }}-amd64
+      - vektra/mockery:{{ .Tag }}-arm64
+  - name_template: vektra/mockery:v{{ .Major }}.{{ .Minor }}
+    image_templates:
+      - vektra/mockery:{{ .Tag }}-amd64
+      - vektra/mockery:{{ .Tag }}-arm64
+  - name_template: vektra/mockery:latest
+    image_templates:
+      - vektra/mockery:{{ .Tag }}-amd64
+      - vektra/mockery:{{ .Tag }}-arm64
 brews:
   - homepage: https://github.com/vektra/mockery
     description: "A mock code autogenerator for Go"


### PR DESCRIPTION
Description
-------------

Uses docker manifests to build 2 separate images, one per arch, pushes them both, and then combines them with common tags, as per the docs: https://goreleaser.com/customization/docker_manifest/

Fixes #440

## Type of change

- CI/Build

Version of Golang used when building/testing:
---------------------------------------------

- [x] 1.18

How Has This Been Tested?
---------------------------

Ran locally and built the images with GoReleaser.

```
  • docker images
    • building docker image                          image=vektra/mockery:v2.14.1-arm64
    • building docker image                          image=vektra/mockery:v2.14.1-amd64
    • took: 15s
```

The manifests command doesn't run unless the release actually happens.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes