### PR TITLE
Set with-expecter to be True by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ test: mocks
 	go test ./...
 
 mocks: $(shell find . -type f -name '*.go' -not -name '*_test.go')
-	go run . --dir pkg/fixtures --output mocks/pkg/fixtures
-	go run . --all=false --print --dir pkg/fixtures --name RequesterVariadic --structname RequesterVariadicOneArgument --unroll-variadic=False > mocks/pkg/fixtures/RequesterVariadicOneArgument.go
-	go run . --all=false --print --dir pkg/fixtures --name Expecter --with-expecter > mocks/pkg/fixtures/Expecter.go
+	go run . --dir pkg/fixtures --output mocks/pkg/fixtures --with-expecter=False
+	go run . --all=false --print --dir pkg/fixtures --name RequesterVariadic --structname RequesterVariadicOneArgument --unroll-variadic=False --with-expecter=False > mocks/pkg/fixtures/RequesterVariadicOneArgument.go
+	go run . --all=false --print --dir pkg/fixtures --name Expecter > mocks/pkg/fixtures/Expecter.go
 	@touch mocks
 
 .PHONY: install

--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -73,7 +73,7 @@ func NewRootCmd() *cobra.Command {
 	pFlags.String("boilerplate-file", "", "File to read a boilerplate text from. Text should be a go block comment, i.e. /* ... */")
 	pFlags.Bool("unroll-variadic", true, "For functions with variadic arguments, do not unroll the arguments into the underlying testify call. Instead, pass variadic slice as-is.")
 	pFlags.Bool("exported", false, "Generates public mocks for private interfaces.")
-	pFlags.Bool("with-expecter", false, "Generate expecter utility around mock's On, Run and Return methods with explicit types. This option is NOT compatible with -unroll-variadic=false")
+	pFlags.Bool("with-expecter", true, "Generate expecter utility around mock's On, Run and Return methods with explicit types. This option is NOT compatible with --unroll-variadic=false")
 
 	viper.BindPFlags(pFlags)
 


### PR DESCRIPTION

Description
-------------

Closes #447

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [x] 1.19

How Has This Been Tested?
---------------------------

Re-ran mock generation that assumes with-expecter is True. Current tests pass.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes

