### PR TITLE
Fix invalid generated code when some return parameters are named but not others

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ mocks: $(shell find . -type f -name '*.go' -not -name '*_test.go')
 	go run . --dir pkg/fixtures --output mocks/pkg/fixtures
 	go run . --all=false --print --dir pkg/fixtures --name RequesterVariadic --structname RequesterVariadicOneArgument --unroll-variadic=False > mocks/pkg/fixtures/RequesterVariadicOneArgument.go
 	go run . --all=false --print --dir pkg/fixtures --name Expecter --with-expecter > mocks/pkg/fixtures/Expecter.go
+	go run . --all=false --print --dir pkg/fixtures --name RequesterReturnElided --with-expecter > mocks/pkg/fixtures/RequesterReturnElided.go
 	@touch mocks
 
 .PHONY: install

--- a/mocks/pkg/fixtures/RequesterReturnElided.go
+++ b/mocks/pkg/fixtures/RequesterReturnElided.go
@@ -9,6 +9,14 @@ type RequesterReturnElided struct {
 	mock.Mock
 }
 
+type RequesterReturnElided_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *RequesterReturnElided) EXPECT() *RequesterReturnElided_Expecter {
+	return &RequesterReturnElided_Expecter{mock: &_m.Mock}
+}
+
 // Get provides a mock function with given fields: path
 func (_m *RequesterReturnElided) Get(path string) (int, int, int, error) {
 	ret := _m.Called(path)
@@ -42,6 +50,73 @@ func (_m *RequesterReturnElided) Get(path string) (int, int, int, error) {
 	}
 
 	return r0, r1, r2, r3
+}
+
+// RequesterReturnElided_Get_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Get'
+type RequesterReturnElided_Get_Call struct {
+	*mock.Call
+}
+
+// Get is a helper method to define mock.On call
+//   - path string
+func (_e *RequesterReturnElided_Expecter) Get(path interface{}) *RequesterReturnElided_Get_Call {
+	return &RequesterReturnElided_Get_Call{Call: _e.mock.On("Get", path)}
+}
+
+func (_c *RequesterReturnElided_Get_Call) Run(run func(path string)) *RequesterReturnElided_Get_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *RequesterReturnElided_Get_Call) Return(a int, b int, c int, err error) *RequesterReturnElided_Get_Call {
+	_c.Call.Return(a, b, c, err)
+	return _c
+}
+
+// Put provides a mock function with given fields: path
+func (_m *RequesterReturnElided) Put(path string) (int, error) {
+	ret := _m.Called(path)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(string) int); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// RequesterReturnElided_Put_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Put'
+type RequesterReturnElided_Put_Call struct {
+	*mock.Call
+}
+
+// Put is a helper method to define mock.On call
+//   - path string
+func (_e *RequesterReturnElided_Expecter) Put(path interface{}) *RequesterReturnElided_Put_Call {
+	return &RequesterReturnElided_Put_Call{Call: _e.mock.On("Put", path)}
+}
+
+func (_c *RequesterReturnElided_Put_Call) Run(run func(path string)) *RequesterReturnElided_Put_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *RequesterReturnElided_Put_Call) Return(_a0 int, err error) *RequesterReturnElided_Put_Call {
+	_c.Call.Return(_a0, err)
+	return _c
 }
 
 type mockConstructorTestingTNewRequesterReturnElided interface {

--- a/pkg/fixtures/requester_ret_elided.go
+++ b/pkg/fixtures/requester_ret_elided.go
@@ -2,4 +2,5 @@ package test
 
 type RequesterReturnElided interface {
 	Get(path string) (a, b, c int, err error)
+	Put(path string) (_ int, err error)
 }

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -193,11 +193,10 @@ func (g *Generator) mockName() string {
 }
 
 // getTypeConstraintString returns type constraint string for a given interface.
-//  For instance, a method using this constraint:
 //
-//    func Foo[T Stringer](s []T) (ret []string) {
-//
-//    }
+//	For instance, a method using this constraint:
+//	  func Foo[T Stringer](s []T) (ret []string) {
+//	  }
 //
 // The constraint returned will be "[T Stringer]"
 //
@@ -518,6 +517,9 @@ func (g *Generator) genList(ctx context.Context, list *types.Tuple, variadic boo
 }
 
 func (g *Generator) nameCollides(pname string) bool {
+	if pname == "_" {
+		return true
+	}
 	if pname == g.pkg {
 		return true
 	}

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -1296,6 +1296,14 @@ type RequesterReturnElided struct {
 	mock.Mock
 }
 
+type RequesterReturnElided_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *RequesterReturnElided) EXPECT() *RequesterReturnElided_Expecter {
+	return &RequesterReturnElided_Expecter{mock: &_m.Mock}
+}
+
 // Get provides a mock function with given fields: path
 func (_m *RequesterReturnElided) Get(path string) (int, int, int, error) {
 	ret := _m.Called(path)
@@ -1331,6 +1339,73 @@ func (_m *RequesterReturnElided) Get(path string) (int, int, int, error) {
 	return r0, r1, r2, r3
 }
 
+// RequesterReturnElided_Get_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Get'
+type RequesterReturnElided_Get_Call struct {
+	*mock.Call
+}
+
+// Get is a helper method to define mock.On call
+//   - path string
+func (_e *RequesterReturnElided_Expecter) Get(path interface{}) *RequesterReturnElided_Get_Call {
+	return &RequesterReturnElided_Get_Call{Call: _e.mock.On("Get", path)}
+}
+
+func (_c *RequesterReturnElided_Get_Call) Run(run func(path string)) *RequesterReturnElided_Get_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *RequesterReturnElided_Get_Call) Return(a int, b int, c int, err error) *RequesterReturnElided_Get_Call {
+	_c.Call.Return(a, b, c, err)
+	return _c
+}
+
+// Put provides a mock function with given fields: path
+func (_m *RequesterReturnElided) Put(path string) (int, error) {
+	ret := _m.Called(path)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(string) int); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// RequesterReturnElided_Put_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Put'
+type RequesterReturnElided_Put_Call struct {
+	*mock.Call
+}
+
+// Put is a helper method to define mock.On call
+//   - path string
+func (_e *RequesterReturnElided_Expecter) Put(path interface{}) *RequesterReturnElided_Put_Call {
+	return &RequesterReturnElided_Put_Call{Call: _e.mock.On("Put", path)}
+}
+
+func (_c *RequesterReturnElided_Put_Call) Run(run func(path string)) *RequesterReturnElided_Put_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *RequesterReturnElided_Put_Call) Return(_a0 int, err error) *RequesterReturnElided_Put_Call {
+	_c.Call.Return(_a0, err)
+	return _c
+}
+
 type mockConstructorTestingTNewRequesterReturnElided interface {
 	mock.TestingT
 	Cleanup(func())
@@ -1346,7 +1421,11 @@ func NewRequesterReturnElided(t mockConstructorTestingTNewRequesterReturnElided)
 	return mock
 }
 `
-	s.checkGeneration("requester_ret_elided.go", "RequesterReturnElided", false, "", expected)
+	cfg := config.Config{
+		WithExpecter: true,
+	}
+
+	s.checkGenerationWithConfig("requester_ret_elided.go", "RequesterReturnElided", cfg, expected)
 }
 
 func (s *GeneratorSuite) TestGeneratorVariadicArgs() {


### PR DESCRIPTION
Description
-------------

Fixes the following bug: If you mock an interface with some returned values named (and others left as _), mockery generates invalid code, as it copies the _ names verbatim when generating the return function.


- Fixes #533

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [X] 1.19

How Has This Been Tested?
---------------------------

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Checklist
-----------

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

