### PR TITLE
Fix regression with legacy config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ fmt:
 	go fmt ./...
 
 .PHONY: test
-test: mocks
+test:
 	go test ./...
 
 .PHONY: mocks


### PR DESCRIPTION


Description
-------------

A regression was introduced whereby when generating mocks using legacy configs, it would crash the program. Unit tests have been added to assert this can't happen anymore.

This fixes #558

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [x] 1.19
- [ ] 1.20

How Has This Been Tested?
---------------------------

Unit tests added

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

