### PR TITLE
fix: don't override c.Dir when it's set

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,7 +87,9 @@ func NewConfigFromViper(v *viper.Viper) (*Config, error) {
 
 	// Set defaults
 	if _, packagesExists := cfgMap["packages"]; !packagesExists {
-		c.Dir = "."
+		if c.Dir == "" {
+			c.Dir = "."
+		}
 	} else {
 		c.Dir = "mocks/{{.PackagePath}}"
 		c.FileName = "mock_{{.InterfaceName}}.go"


### PR DESCRIPTION
Description
-------------

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

- Fixes #568 
Fixed so if `c.Dir` config is set we will use that and only override when empty


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [X] 1.20

How Has This Been Tested?
---------------------------

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Test with the code on the issue so it still respects `dir` flag when set 

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

