### PR TITLE
Add `InterfaceDir` template variable

### DIFF
--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -147,11 +147,13 @@ func outputFilePath(
 
 	// The fields available to the template strings
 	data := struct {
+		InterfaceDir  string
 		InterfaceName string
 		PackageName   string
 		PackagePath   string
 		MockName      string
 	}{
+		InterfaceDir:  filepath.Dir(iface.FileName),
 		InterfaceName: iface.Name,
 		PackageName:   iface.Pkg.Name(),
 		PackagePath:   iface.Pkg.Path(),

--- a/pkg/outputter_test.go
+++ b/pkg/outputter_test.go
@@ -95,6 +95,7 @@ func Test_outputFilePath(t *testing.T) {
 		packageName      string
 		packagePath      string
 		interfaceName    string
+		fileName         string
 		fileNameTemplate string
 		dirTemplate      string
 		mockName         string
@@ -128,6 +129,19 @@ func Test_outputFilePath(t *testing.T) {
 			},
 			want: pathlib.NewPath("github.com/vektra/mockery/MockFoo_pkg_Foo.go"),
 		},
+		{
+			name: "mock next to original interface",
+			params: parameters{
+				packageName:      "pkg",
+				packagePath:      "github.com/vektra/mockery/pkg/internal",
+				interfaceName:    "Foo",
+				fileName:         "pkg/internal/foo.go",
+				dirTemplate:      "{{.InterfaceDir}}",
+				fileNameTemplate: "mock_{{.InterfaceName}}.go",
+				mockName:         "MockFoo",
+			},
+			want: pathlib.NewPath("pkg/internal/mock_Foo.go"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -136,8 +150,9 @@ func Test_outputFilePath(t *testing.T) {
 			mockPackage.EXPECT().Path().Return(tt.params.packagePath)
 
 			iface := &Interface{
-				Name: tt.params.interfaceName,
-				Pkg:  mockPackage,
+				Name:     tt.params.interfaceName,
+				Pkg:      mockPackage,
+				FileName: tt.params.fileName,
 			}
 
 			got, err := outputFilePath(


### PR DESCRIPTION
Description
-------------

Adding a new template variable `InterfaceDir`. This will be used to place your mocks next to your original mocked interface.

This fixes #574

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [x] 1.19
- [ ] 1.20

How Has This Been Tested?
---------------------------

Unit tests

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

