### PR TITLE
Templating variables and casing options

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -50,18 +50,110 @@ packages:
 3. This is telling mockery to generate _all_ interfaces in the `io` package.
 4. We can provide interface-specifc overrides to the generation config.
 
-### Templated directory and filenames
+### Templated variables
 
-Included with this feature is the ability to use templated strings for the destination directory and filenames of the generated mocks.
+Included with this feature is the ability to use templated strings for various configuration options. This is useful to define where your mocks are placed and how to name them.
+    
+These are various strategies you may want to adopt:
 
-The following options are capable of using template variables. These are their defaults:
+#### Strategies
 
-```yaml title="Defaults"
-filename: "mock_{{.InterfaceName}}.go"
-dir: "mocks/{{.PackagePath}}"
-structname: "Mock{{.InterfaceName}}"
-outpkg: "{{.PackageName}}"
-```
+!!! info "Strategies"
+
+    === "defaults"
+
+        ```yaml
+        filename: "mock_{{.InterfaceName}}.go"
+        dir: "mocks/{{.PackagePath}}"
+        structname: "Mock{{.InterfaceName}}"
+        outpkg: "{{.PackageName}}"
+        ```
+
+        If these variables aren't specified, the above values will be applied to the config options. This strategy places your mocks into a separate `mocks/` directory.
+
+        **Interface Description**
+
+        | name | value |
+        |------|-------|
+        | `InterfaceName` | `MyDatabase` |
+        | `PackagePath` | `github.com/user/project/pkgName` |
+        | `PackageName` | `pkgName` |
+
+        **Output**
+
+        The mock will be generated at:
+
+        ```
+        mocks/github.com/user/project/pkgName/mock_MyDatabase.go
+        ```
+
+        The mock file will look like:
+
+        ```go
+        package pkgName
+
+        import mock "github.com/stretchr/testify/mock"
+
+        type MockMyDatabase struct {
+          mock.Mock
+        }
+        ```
+    === "adjacent to interface"
+
+        !!! failure
+
+            This strategy is not yet functional.
+        
+        ```yaml
+        filename: "mock_{{.InterfaceName}}.go"
+        dir: "{{.PackagePathRelative}}"
+        structname: "Mock{{.InterfaceName}}"
+        outpkg: "{{.PackageName}}"
+        ```
+
+        Instead of the mocks being generated in a different folder, you may elect to generate the mocks alongside the original interface in your package. This may be the way most people define their configs, as it removes circular import issues that can happen with the default config.
+
+        For example, the mock might be generated along side the original source file like this:
+
+        ```
+        ./path/to/pkg/db.go
+        ./path/to/pkg/mock_MyDatabase.go
+        ```
+
+        **Interface Description**
+
+        | name | value |
+        |------|-------|
+        | `InterfaceName` | `MyDatabase` |
+        | `PackagePath` | `github.com/user/project/path/to/pkg`
+        | `PackagePathRelative` | `path/to/pkg` |
+        | `PackageName` | `pkgName` |
+        | `SourceFile` | `./path/to/pkg/db.go` |
+
+        **Output**
+
+        Mock file will be generated at:
+
+        ```
+        ./path/to/pkg/mock_MyDatabase.go
+        ```
+
+        The mock file will look like:
+
+        ```go
+        package pkgName
+
+        import mock "github.com/stretchr/testify/mock"
+
+        type MockMyDatabase struct {
+          mock.Mock
+        }
+        ```
+        
+        
+
+
+#### Template Variable Descriptions
 
 The template variables available for your use are:
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -62,11 +62,17 @@ dir: "mocks/{{.PackagePath}}"
 ```
 
 The template variables available for your use are:
+		InterfaceNameCamel      string
+		InterfaceNameLowerCamel string
+		InterfaceNameSnake      string
 
 | name | description |
 |------|-------------|
 | InterfaceDir | The path of the original interface being mocked. This can be used as `#!yaml dir: "{{.InterfaceDir}}"` to place your mocks adjacent to the original interface. This should not be used for external interfaces. |
 | InterfaceName | The name of the original interface being mocked |
+| InterfaceNameCamel | Converts the `InterfaceName` to camel case |
+| InterfaceNameLowerCamel | Converts `InterfaceName` to `interfaceName` |
+| InterfaceNameSnake | Converts `InterfaceName` to `interface_name` |
 | PackageName | The name of the package from the original interface |
 | Package Path | The fully qualified package path of the original interface |
 | MockName | The name of the generated mock |

--- a/docs/features.md
+++ b/docs/features.md
@@ -54,32 +54,30 @@ packages:
 
 Included with this feature is the ability to use templated strings for the destination directory and filenames of the generated mocks.
 
-The default parameters are:
+The following options are capable of using template variables. These are their defaults:
 
 ```yaml title="Defaults"
 filename: "mock_{{.InterfaceName}}.go"
 dir: "mocks/{{.PackagePath}}"
+structname: "Mock{{.InterfaceName}}"
+outpkg: "{{.PackageName}}"
 ```
 
 The template variables available for your use are:
-		InterfaceNameCamel      string
-		InterfaceNameLowerCamel string
-		InterfaceNameSnake      string
 
 | name | description |
 |------|-------------|
 | InterfaceDir | The path of the original interface being mocked. This can be used as `#!yaml dir: "{{.InterfaceDir}}"` to place your mocks adjacent to the original interface. This should not be used for external interfaces. |
 | InterfaceName | The name of the original interface being mocked |
-| InterfaceNameCamel | Converts the `InterfaceName` to camel case |
+| InterfaceNameCamel | Converts a string `interface_name` to `InterfaceName` |
 | InterfaceNameLowerCamel | Converts `InterfaceName` to `interfaceName` |
 | InterfaceNameSnake | Converts `InterfaceName` to `interface_name` |
 | PackageName | The name of the package from the original interface |
-| Package Path | The fully qualified package path of the original interface |
-| MockName | The name of the generated mock |
+| PackagePath | The fully qualified package path of the original interface |
 
 
-!!! warn
-    Many of the config options when using `packages` have either changed meanings or are no longer used.
+!!! warning
+    Many of the config options when using `packages` have either changed meanings or are no longer used. It's recommended to delete all previous configuration you have as their meanings may have changed.
 
 Mock Constructors
 -----------------

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,8 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.details
   - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true 
   - toc:
       permalink: true
   

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,6 +91,8 @@ func NewConfigFromViper(v *viper.Viper) (*Config, error) {
 	} else {
 		v.SetDefault("dir", "mocks/{{.PackagePath}}")
 		v.SetDefault("filename", "mock_{{.InterfaceName}}.go")
+		v.SetDefault("structname", "Mock{{.InterfaceName}}")
+		v.SetDefault("outpkg", "{{.PackageName}}")
 	}
 
 	if err := v.UnmarshalExact(c); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -591,8 +591,10 @@ packages:
   github.com/vektra/mockery/v2/pkg:
 `,
 			want: &Config{
-				Dir:      "mocks/{{.PackagePath}}",
-				FileName: "mock_{{.InterfaceName}}.go",
+				Dir:        "mocks/{{.PackagePath}}",
+				FileName:   "mock_{{.InterfaceName}}.go",
+				StructName: "Mock{{.InterfaceName}}",
+				Outpkg:     "{{.PackageName}}",
 			},
 		},
 		{
@@ -604,8 +606,10 @@ packages:
   github.com/vektra/mockery/v2/pkg:
 `,
 			want: &Config{
-				Dir:      "barfoo",
-				FileName: "foobar.go",
+				Dir:        "barfoo",
+				FileName:   "foobar.go",
+				StructName: "Mock{{.InterfaceName}}",
+				Outpkg:     "{{.PackageName}}",
 			},
 		},
 	}

--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/chigopher/pathlib"
+	"github.com/iancoleman/strcase"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 
@@ -147,17 +148,23 @@ func outputFilePath(
 
 	// The fields available to the template strings
 	data := struct {
-		InterfaceDir  string
-		InterfaceName string
-		PackageName   string
-		PackagePath   string
-		MockName      string
+		InterfaceDir            string
+		InterfaceName           string
+		InterfaceNameCamel      string
+		InterfaceNameLowerCamel string
+		InterfaceNameSnake      string
+		PackageName             string
+		PackagePath             string
+		MockName                string
 	}{
-		InterfaceDir:  filepath.Dir(iface.FileName),
-		InterfaceName: iface.Name,
-		PackageName:   iface.Pkg.Name(),
-		PackagePath:   iface.Pkg.Path(),
-		MockName:      mockName,
+		InterfaceDir:            filepath.Dir(iface.FileName),
+		InterfaceName:           iface.Name,
+		InterfaceNameCamel:      strcase.ToCamel(iface.Name),
+		InterfaceNameLowerCamel: strcase.ToLowerCamel(iface.Name),
+		InterfaceNameSnake:      strcase.ToSnake(iface.Name),
+		PackageName:             iface.Pkg.Name(),
+		PackagePath:             iface.Pkg.Path(),
+		MockName:                mockName,
 	}
 
 	// Get the name of the file from a template string


### PR DESCRIPTION
Description
-------------

This PR adds a few additional config options to the templating engine. The two variables added, along with their defaults, are:

```yaml
structname: "Mock{{.InterfaceName}}"
outpkg: "{{.PackageName}}"
```

We also add more variables to the template namespace.

| name | description |
|------|-------------|
|InterfaceNameCamel | Converts a string `interface_name` to `InterfaceName` |
| InterfaceNameLowerCamel | Converts `InterfaceName` to `interfaceName` |
| InterfaceNameSnake | Converts `InterfaceName` to `interface_name` |

We delete the `MockName` template variable as this is not actually needed... mock names are controlled by the `structname` variable, and we set a default for that.

- Fixes #577 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [x] 1.19
- [ ] 1.20

How Has This Been Tested?
---------------------------

Unit tests added

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

