### PR TITLE
Move config search disabled message to debug log

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -161,7 +161,7 @@ func initConfig(
 			log.Info().Msg("couldn't read any config file")
 		}
 	} else {
-		fmt.Printf("config search disabled\n")
+		log.Debug().Msg("config search disabled")
 	}
 
 	viperObj.Set("config", viperObj.ConfigFileUsed())


### PR DESCRIPTION
Before this change the `config search disabled` message would end up in the generated code

Description
-------------

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

- Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [ ] 1.20

How Has This Been Tested?
---------------------------

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

