### PR TITLE
Simplify docs, add more explanations

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,11 @@ Changelog
 
 This changelog describes major feature additions. Please view the `releases` page for more details on commits and minor changes.
 
+### :octicons-tag-24: [`v2.23.0`](https://github.com/vektra/mockery/releases/tag/v2.23.0) Replace Types
+
+The `replace-type` parameter allows adding a list of type replacements to be made in package and/or type names.
+This can help overcome issues like usage of type aliases that point to internal packages.
+
 ### :octicons-tag-24: [`v2.21.0`](https://github.com/vektra/mockery/releases/tag/v2.21.0): `#!yaml packages` configuration
 
 In this version we release the `#!yaml packages` configuration section. This new parameter allows defining specific packages to generate mocks for, while also giving fine-grained control over which interfaces are mocked, where they are located, and how they are configured. Details are provided [here](/mockery/features/#packages-configuration).

--- a/docs/features.md
+++ b/docs/features.md
@@ -272,10 +272,18 @@ Return(
 Replace Types
 -------------
 
-The `replace-type` parameter allows adding a list of type replacements to be made in package and/or type names.
-This can help overcome some parsing problems like type aliases that the Go parser doesn't provide enough information.
+:octicons-tag-24: 2.20.0
 
-This parameter can be specified multiple times.
+The `replace-type` parameter allows adding a list of type replacements to be made in package and/or type names.
+This can help overcome issues like usage of type aliases that point to internal packages.
+
+The format of the parameter is:
+
+
+`originalPackagePath.originalTypeName=newPackageName:newPackagePath.newTypeName`
+
+
+For example:
 
 ```shell
 mockery --replace-type github.com/vektra/mockery/v2/baz/internal/foo.InternalBaz=baz:github.com/vektra/mockery/v2/baz.Baz
@@ -300,7 +308,7 @@ type Message = ipubsub.Message
 The Go parser that mockery uses doesn't provide a way to detect this alias and sends the application the package and
 type name of the type in the internal package, which will not work.
 
-We can use "replace-type" with only the package part to replace any import of `cloud.google.com/go/internal/pubsub` to
+We can use `replace-type` with only the package part to replace any import of `cloud.google.com/go/internal/pubsub` to
 `cloud.google.com/go/pubsub`. We don't need to change the alias or type name in this case, because they are `pubsub`
 and `Message` in both cases.
 

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -1,6 +1,38 @@
 Additional Notes
 ================
 
+Multiple Expectations With Identical Arguments
+-----------------------------------------------
+
+There might be instances where you want a mock to return different values on successive calls that provide the same arguments. For example we might want to test this behavior:
+
+```go
+// Return "foo" on the first call
+getter := NewGetter()
+assert(t, "foo", getter.Get("key"))
+
+// Return "bar" on the second call
+assert(t, "bar", getter.Get("key"))
+```
+
+This can be done by using the `.Once()`  method on the mock call expectation:
+
+```go
+mockGetter := NewMockGetter(t)
+mockGetter.EXPECT().Get(mock.anything).Return("foo").Once()
+mockGetter.EXPECT().Get(mock.anything).Return("bar").Once()
+```
+
+Or you can identify an arbitrary number of times each value should be returned:
+
+```go
+mockGetter := NewMockGetter(t)
+mockGetter.EXPECT().Get(mock.anything).Return("foo").Times(4)
+mockGetter.EXPECT().Get(mock.anything).Return("bar").Times(2)
+```
+
+Note that with proper Golang support in your IDE, all of the available methods are self-documented in auto-completion help contexts.
+
 Variadic Arguments
 ------------------
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,8 +30,6 @@ theme:
     - content.action.view
     - navigation.indexes
     - navigation.sections
-    #- navigation.tabs
-    #- navigation.tabs.sticky
     - navigation.tracking
     - toc.follow
 markdown_extensions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,8 +30,8 @@ theme:
     - content.action.view
     - navigation.indexes
     - navigation.sections
-    - navigation.tabs
-    - navigation.tabs.sticky
+    #- navigation.tabs
+    #- navigation.tabs.sticky
     - navigation.tracking
     - toc.follow
 markdown_extensions:


### PR DESCRIPTION
This fixes #563

- Simplify some grammar in docs
- Add documentation about specifying number of expectations