### PR TITLE
Exclude subdirectories and files with --exclude

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -55,6 +55,7 @@ func NewRootCmd() *cobra.Command {
 	pFlags.String("packageprefix", "", "prefix for the generated package name, it is ignored if outpkg is also specified.")
 	pFlags.String("dir", "", "directory to search for interfaces")
 	pFlags.BoolP("recursive", "r", false, "recurse search into sub-directories")
+	pFlags.StringArray("exclude", nil, "prefixes of subdirectories and files to exclude from search")
 	pFlags.Bool("all", false, "generates mocks for all found interfaces in all sub-directories")
 	pFlags.Bool("inpackage", false, "generate a mock that goes inside the original package")
 	pFlags.Bool("inpackage-suffix", false, "use filename '_mock' suffix instead of 'mock_' prefix for InPackage mocks")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/chigopher/pathlib"
 	"github.com/jinzhu/copier"
@@ -58,6 +59,7 @@ type Config struct {
 	Profile              string                 `mapstructure:"profile"`
 	Quiet                bool                   `mapstructure:"quiet"`
 	Recursive            bool                   `mapstructure:"recursive"`
+	Exclude              []string               `mapstructure:"exclude"`
 	SrcPkg               string                 `mapstructure:"srcpkg"`
 	BoilerplateFile      string                 `mapstructure:"boilerplate-file"`
 	// StructName overrides the name given to the mock struct and should only be nonempty
@@ -225,6 +227,15 @@ func (c *Config) GetPackageConfig(ctx context.Context, packageName string) (*Con
 	}
 	c.pkgConfigCache[packageName] = pkgConfigTyped
 	return pkgConfigTyped, nil
+}
+
+func (c *Config) ExcludePath(path string) bool {
+	for _, ex := range c.Exclude {
+		if strings.HasPrefix(path, ex) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Config) ShouldGenerateInterface(ctx context.Context, packageName, interfaceName string) (bool, error) {

--- a/pkg/walker.go
+++ b/pkg/walker.go
@@ -49,6 +49,10 @@ func (w *Walker) Walk(ctx context.Context, visitor WalkerVisitor) (generated boo
 			continue
 		}
 
+		if w.ExcludePath(iface.FileName) {
+			continue
+		}
+
 		if !w.Filter.MatchString(iface.Name) {
 			continue
 		}
@@ -81,6 +85,10 @@ func (w *Walker) doWalk(ctx context.Context, parser *Parser, dir string) (genera
 		}
 
 		path := filepath.Join(dir, file.Name())
+		if w.ExcludePath(path) {
+			continue
+		}
+
 		if file.IsDir() {
 			if w.Recursive {
 				generated = w.doWalk(ctx, parser, path) || generated


### PR DESCRIPTION
Description
-------------

Add `--exclude` CLI parameter to exclude subdirectories when using `--all`.
The flag `--exclude` can be used more than once on the same call, for example:
```
mockery --dir . --inpackage --all --with-expecter --case underscore --recursive --exclude vendor --exclude resources/providers/
```

- Fixes #395 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [x] 1.19
- [x] 1.20

How Has This Been Tested?
---------------------------

I built the binary, copied it to another project, and generated mocks using the command:
```
./mockery --dir . --inpackage --all --with-expecter --case underscore --recursive
```
I tried to exclude different paths in the project and used the new flag multiple times to make sure all paths were excluded.

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

