### PR TITLE
Drop config search disabled message

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -163,8 +163,6 @@ func initConfig(
 			log.Debug().Err(err).Msg("failed to read in config")
 			log.Info().Msg("couldn't read any config file")
 		}
-	} else {
-		log.Debug().Msg("config search disabled")
 	}
 
 	viperObj.Set("config", viperObj.ConfigFileUsed())


### PR DESCRIPTION
This message happens before cli parsing so its not possible to suppress the output via --log-level

This message is not useful

Description
-------------

Drops the message moved to debug log in https://github.com/vektra/mockery/pull/583 

I have kind of a unique usecase of wrapping mockery in bazel in a large monorepo. Our usage doesn't require a config file but this log message is logged very frequently in our build even with `--log-level error`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [ ] 1.20

How Has This Been Tested?
---------------------------

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

