### PR TITLE
Add `Mock` template variable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,11 +97,12 @@ Parameter Descriptions
 
     | name | description |
     |------|-------------|
-    | InterfaceDir | The path of the original interface being mocked. This can be used as `#!yaml dir: "{{.InterfaceDir}}"` to place your mocks adjacent to the original interface. This should not be used for external interfaces. |
+    | InterfaceDir | The path of the original interface being mocked. This can be used as <br>`#!yaml dir: "{{.InterfaceDir}}"` to place your mocks adjacent to the original interface. This should not be used for external interfaces. |
     | InterfaceName | The name of the original interface being mocked |
     | InterfaceNameCamel | Converts a string `interface_name` to `InterfaceName` |
     | InterfaceNameLowerCamel | Converts `InterfaceName` to `interfaceName` |
     | InterfaceNameSnake | Converts `InterfaceName` to `interface_name` |
+    | Mock | A string that is `Mock` if the interface is exported, or `mock` if it is not exported. Useful when setting the name of your mock to something like: <br>`#!yaml mockname: "{{.Mock}}{{.InterfaceName}}"`<br> This way, the mock name will retain the exported-ness of the original interface.
     | MockName | The name of the mock that will be generated. Note that this is simply the `mockname` configuration variable |
     | PackageName | The name of the package from the original interface |
     | PackagePath | The fully qualified package path of the original interface |

--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"go/ast"
 	"io"
 	"os"
 	"path/filepath"
@@ -136,6 +137,13 @@ func (*FileOutputStreamProvider) underscoreCaseName(caseName string) string {
 func parseConfigTemplates(ctx context.Context, c *config.Config, iface *Interface) error {
 	log := zerolog.Ctx(ctx)
 
+	isExported := ast.IsExported(iface.Name)
+	var mock string
+	if isExported {
+		mock = "Mock"
+	} else {
+		mock = "mock"
+	}
 	// data is the struct sent to the template parser
 	data := struct {
 		InterfaceDir            string
@@ -143,6 +151,7 @@ func parseConfigTemplates(ctx context.Context, c *config.Config, iface *Interfac
 		InterfaceNameCamel      string
 		InterfaceNameLowerCamel string
 		InterfaceNameSnake      string
+		Mock                    string
 		MockName                string
 		PackageName             string
 		PackagePath             string
@@ -152,6 +161,7 @@ func parseConfigTemplates(ctx context.Context, c *config.Config, iface *Interfac
 		InterfaceNameCamel:      strcase.ToCamel(iface.Name),
 		InterfaceNameLowerCamel: strcase.ToLowerCamel(iface.Name),
 		InterfaceNameSnake:      strcase.ToSnake(iface.Name),
+		Mock:                    mock,
 		MockName:                c.MockName,
 		PackageName:             iface.Pkg.Name(),
 		PackagePath:             iface.Pkg.Path(),


### PR DESCRIPTION
This is a string that will be either `Mock` or `mock`, depending on the exported-ness of the interface.
