### PR TITLE
Remove debug log when reading config is failed

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -160,7 +160,6 @@ func initConfig(
 		}
 		if err := viperObj.ReadInConfig(); err != nil {
 			log, _ := logging.GetLogger("debug")
-			log.Debug().Err(err).Msg("failed to read in config")
 			log.Info().Msg("couldn't read any config file")
 		}
 	}


### PR DESCRIPTION
Description
-------------

Remove debug log when reading config is failed.

- Fixes #613 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [X] 1.20

How Has This Been Tested?
---------------------------

```
➜  mockery git:(neverbeenthisweeb/613-remove-debug-msg) go-task test 
task: [test] go test -v -coverprofile=coverage.txt ./...
```

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

