### PR TITLE
Rip out all usages of github.com/pkg/errors

### DIFF
--- a/cmd/showconfig.go
+++ b/cmd/showconfig.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/vektra/mockery/v2/pkg/config"
@@ -35,7 +34,7 @@ func showConfig(
 	ctx := context.Background()
 	config, err := config.NewConfigFromViper(v)
 	if err != nil {
-		return errors.Wrapf(err, "failed to unmarshal config")
+		return fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 	if err := config.Initialize(ctx); err != nil {
 		return err
@@ -46,7 +45,7 @@ func showConfig(
 	}
 	out, err := yaml.Marshal(cfgMap)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to marshal yaml")
+		return fmt.Errorf("failed to marshal yaml: %w", err)
 	}
 	log, err := logging.GetLogger(config.LogLevel)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -167,7 +167,6 @@ github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvI
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,11 +1,11 @@
 package logging
 
 import (
+	"fmt"
 	"os"
 	"runtime/debug"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"golang.org/x/term"
 )
@@ -25,7 +25,7 @@ const (
 
 // SemVer is the version of mockery at build time.
 var SemVer = ""
-var ErrPkgNotExist = errors.New("package does not exist")
+var ErrPkgNotExist = fmt.Errorf("package does not exist")
 
 func GetSemverInfo() string {
 	if SemVer != "" {
@@ -47,7 +47,7 @@ func (t timeHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
 func GetLogger(levelStr string) (zerolog.Logger, error) {
 	level, err := zerolog.ParseLevel(levelStr)
 	if err != nil {
-		return zerolog.Logger{}, errors.Wrapf(err, "Couldn't parse log level")
+		return zerolog.Logger{}, fmt.Errorf("couldn't parse log level: %w", err)
 	}
 	out := os.Stderr
 	writer := zerolog.ConsoleWriter{

--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/chigopher/pathlib"
 	"github.com/iancoleman/strcase"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 
 	"github.com/vektra/mockery/v2/pkg/config"
@@ -293,18 +292,18 @@ func (m *Outputter) Generate(ctx context.Context, iface *Interface) error {
 
 		outputPath := pathlib.NewPath(interfaceConfig.Dir).Join(interfaceConfig.FileName)
 		if err := outputPath.Parent().MkdirAll(); err != nil {
-			return errors.Wrapf(err, "failed to mkdir parents of: %v", outputPath)
+			return fmt.Errorf("failed to mkdir parents of: %v: %w", outputPath, err)
 		}
 
 		fileLog := log.With().Stringer(logging.LogKeyFile, outputPath).Logger()
 		fileLog.Info().Msg("writing to file")
 		file, err := outputPath.OpenFile(os.O_RDWR | os.O_CREATE | os.O_TRUNC)
 		if err != nil {
-			return errors.Wrapf(err, "failed to open output file for mock: %v", outputPath)
+			return fmt.Errorf("failed to open output file for mock: %v: %w", outputPath, err)
 		}
 		defer file.Close()
 		if err := generator.Write(file); err != nil {
-			return errors.Wrapf(err, "failed to write to file")
+			return fmt.Errorf("failed to write to file: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Description
-------------

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

- Fixes #616 
This package has been deprecated and archived, we should not use it anymore. Replace all instances of pkg/errors with the golang-standard packages. Use the %w wrapping directive from fmt.Errorf to add contextual information to errors.
As golang-standard packages do not support printing stacktrace of errors, the corresponding function replaced with a simple print
## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [ x] 1.20

How Has This Been Tested?
---------------------------

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


Checklist
-----------

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes

