### PR TITLE
Add `InterfaceDirRelative` template variable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,8 @@ These are the config options when using the `packages` config option. Use of the
 
     | name | description |
     |------|-------------|
-    | InterfaceDir | The path of the original interface being mocked. This can be used as <br>`#!yaml dir: "{{.InterfaceDir}}"` to place your mocks adjacent to the original interface. This should not be used for external interfaces. |
+    | InterfaceDir | The directory path of the original interface being mocked. This can be used as <br>`#!yaml dir: "{{.InterfaceDir}}"` to place your mocks adjacent to the original interface. This should not be used for external interfaces. |
+    | InterfaceDirRelative | The directory path of the original interface being mocked, relative to the current working directory. If the path cannot be made relative to the current working directory, this variable will be set equal to `PackagePath` |
     | InterfaceName | The name of the original interface being mocked |
     | InterfaceNameCamel | Converts a string `interface_name` to `InterfaceName` |
     | InterfaceNameLowerCamel | Converts `InterfaceName` to `interfaceName` |

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/vektra/mockery/v2
 go 1.19
 
 require (
-	github.com/chigopher/pathlib v0.13.0
+	github.com/chigopher/pathlib v1.0.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/jinzhu/copier v0.3.5
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.work.sum
+++ b/go.work.sum
@@ -294,6 +294,8 @@ github.com/census-instrumentation/opencensus-proto v0.3.0 h1:t/LhUZLVitR1Ow2YOnd
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/chigopher/pathlib v1.0.0 h1:SbsCrFX4vDf4M2d8mT/RTzuVlKOjTKoPHK0HidsQFak=
+github.com/chigopher/pathlib v1.0.0/go.mod h1:3+YPPV21mU9vyw8Mjp+F33CyCfE6iOzinpiqBcccv7I=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=


### PR DESCRIPTION
This fixes #623

Also fixed in here was a bug where the template object was being reused. This caused subtle issues where if a templated variable was set to the empty string, the template would simply reuse the last parsed template.