### PR TITLE
Add link to documentation for root packages with no go files

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,7 +41,7 @@ tasks:
       - go run github.com/golangci/golangci-lint/cmd/golangci-lint run
   
   test.ci:
-    deps: [test, fmt, mocks, lint]
+    deps: [fmt, lint, mocks, test]
 
   default:
     deps: [test.ci]

--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -36,13 +36,16 @@ func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mockery",
 		Short: "Generate mock objects for your Golang interfaces",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			r, err := GetRootAppFromViper(viperCfg)
 			if err != nil {
 				printStackTrace(err)
-				return err
+				os.Exit(1)
 			}
-			return r.Run()
+			if err := r.Run(); err != nil {
+				printStackTrace(err)
+				os.Exit(1)
+			}
 		},
 	}
 
@@ -104,7 +107,6 @@ func printStackTrace(e error) {
 // Execute executes the cobra CLI workflow
 func Execute() {
 	if err := NewRootCmd().Execute(); err != nil {
-		// printStackTrace(err)
 		os.Exit(1)
 	}
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -510,6 +510,7 @@ github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e h1:MZM7FHLqUHYI0Y/mQAt
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041 h1:llrF3Fs4018ePo4+G/HV/uQUqEI1HMDjCeOf2V6puPc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/tklauser/go-sysconf v0.3.11 h1:89WgdJhk5SNwJfu+GKyYveZ4IaJ7xAkecBo+KdJV0CM=
 github.com/tklauser/numcpus v0.6.0 h1:kebhY2Qt+3U6RNK7UqpYNA+tJ23IBEGKkB7JQBfDYms=

--- a/pkg/fixtures/pkg_with_no_files/subpkg/foo.go
+++ b/pkg/fixtures/pkg_with_no_files/subpkg/foo.go
@@ -1,0 +1,1 @@
+package foo


### PR DESCRIPTION
Description
-------------

There appears to be a limitation with the go package parser when you attempt to load a package with no files. I can't find a way to get information about where the package is located on-disk unless at least 1 go file exists. I added docs that explain this case and linked to it in the logs.

```
02 Jun 23 12:30 EDT ERR package contains no go files error="no go files found in root search path" documentation=https://vektra.github.io/mockery/notes/#error-no-go-files-found-in-root-search-path dry-run=false package-path=github.com/vektra/mockery/v2/pkg/fixtures/pkg_with_no_files version=v0.0.0-dev
```

- Fixes #611 
- Fixes #631 
- #636 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [x] 1.20

How Has This Been Tested?
---------------------------

Unit tests

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

