### PR TITLE
Remove github.com/pkg/errors

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -91,15 +91,11 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
-type stacker interface {
-	Stack() []byte
-}
-
 func printStackTrace(e error) {
 	fmt.Printf("%v\n", e)
-	var s stacker
-	if errors.As(e, &s) {
-		fmt.Printf("%+s\n", s.Stack())
+
+	if stack, ok := stackerr.GetStack(e); ok {
+		fmt.Printf("%+s\n", stack)
 	}
 }
 

--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/chigopher/pathlib"
 	"github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -19,6 +19,7 @@ import (
 	"github.com/vektra/mockery/v2/pkg"
 	"github.com/vektra/mockery/v2/pkg/config"
 	"github.com/vektra/mockery/v2/pkg/logging"
+	"github.com/vektra/mockery/v2/pkg/stackerr"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -90,18 +91,16 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
-type stackTracer interface {
-	StackTrace() errors.StackTrace
+type stacker interface {
+	Stack() []byte
 }
 
 func printStackTrace(e error) {
 	fmt.Printf("%v\n", e)
-	if err, ok := e.(stackTracer); ok {
-		for _, f := range err.StackTrace() {
-			fmt.Printf("%+s:%d\n", f, f)
-		}
+	var s stacker
+	if errors.As(e, &s) {
+		fmt.Printf("%+s\n", s.Stack())
 	}
-
 }
 
 // Execute executes the cobra CLI workflow
@@ -180,7 +179,7 @@ func GetRootAppFromViper(v *viper.Viper) (*RootApp, error) {
 	r := &RootApp{}
 	config, err := config.NewConfigFromViper(v)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get config")
+		return nil, stackerr.NewStackErrf(err, "failed to get config")
 	}
 	r.Config = *config
 	return r, nil
@@ -325,7 +324,7 @@ func (r *RootApp) Run() error {
 		if r.Config.Profile != "" {
 			f, err := os.Create(r.Config.Profile)
 			if err != nil {
-				return errors.Wrapf(err, "Failed to create profile file")
+				return stackerr.NewStackErrf(err, "Failed to create profile file")
 			}
 
 			if err := pprof.StartCPUProfile(f); err != nil {

--- a/cmd/showconfig.go
+++ b/cmd/showconfig.go
@@ -6,11 +6,11 @@ import (
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/vektra/mockery/v2/pkg/config"
 	"github.com/vektra/mockery/v2/pkg/logging"
+	"github.com/vektra/mockery/v2/pkg/stackerr"
 	"gopkg.in/yaml.v2"
 )
 
@@ -35,7 +35,7 @@ func showConfig(
 	ctx := context.Background()
 	config, err := config.NewConfigFromViper(v)
 	if err != nil {
-		return errors.Wrapf(err, "failed to unmarshal config")
+		return stackerr.NewStackErrf(err, "failed to unmarshal config")
 	}
 	if err := config.Initialize(ctx); err != nil {
 		return err
@@ -46,7 +46,7 @@ func showConfig(
 	}
 	out, err := yaml.Marshal(cfgMap)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to marshal yaml")
+		return stackerr.NewStackErrf(err, "failed to marshal yaml")
 	}
 	log, err := logging.GetLogger(config.LogLevel)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -166,7 +166,6 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,12 +1,13 @@
 package logging
 
 import (
+	"errors"
 	"os"
 	"runtime/debug"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
+	"github.com/vektra/mockery/v2/pkg/stackerr"
 	"golang.org/x/term"
 )
 
@@ -47,7 +48,7 @@ func (t timeHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
 func GetLogger(levelStr string) (zerolog.Logger, error) {
 	level, err := zerolog.ParseLevel(levelStr)
 	if err != nil {
-		return zerolog.Logger{}, errors.Wrapf(err, "Couldn't parse log level")
+		return zerolog.Logger{}, stackerr.NewStackErrf(err, "Couldn't parse log level")
 	}
 	out := os.Stderr
 	writer := zerolog.ConsoleWriter{

--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"go/ast"
 	"io"
@@ -14,11 +15,11 @@ import (
 
 	"github.com/chigopher/pathlib"
 	"github.com/iancoleman/strcase"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 
 	"github.com/vektra/mockery/v2/pkg/config"
 	"github.com/vektra/mockery/v2/pkg/logging"
+	"github.com/vektra/mockery/v2/pkg/stackerr"
 )
 
 var (
@@ -312,18 +313,18 @@ func (m *Outputter) Generate(ctx context.Context, iface *Interface) error {
 
 		outputPath := pathlib.NewPath(interfaceConfig.Dir).Join(interfaceConfig.FileName)
 		if err := outputPath.Parent().MkdirAll(); err != nil {
-			return errors.Wrapf(err, "failed to mkdir parents of: %v", outputPath)
+			return stackerr.NewStackErrf(err, "failed to mkdir parents of: %v", outputPath)
 		}
 
 		fileLog := log.With().Stringer(logging.LogKeyFile, outputPath).Logger()
 		fileLog.Info().Msg("writing to file")
 		file, err := outputPath.OpenFile(os.O_RDWR | os.O_CREATE | os.O_TRUNC)
 		if err != nil {
-			return errors.Wrapf(err, "failed to open output file for mock: %v", outputPath)
+			return stackerr.NewStackErrf(err, "failed to open output file for mock: %v", outputPath)
 		}
 		defer file.Close()
 		if err := generator.Write(file); err != nil {
-			return errors.Wrapf(err, "failed to write to file")
+			return stackerr.NewStackErrf(err, "failed to write to file")
 		}
 	}
 	return nil

--- a/pkg/stackerr/stackerr.go
+++ b/pkg/stackerr/stackerr.go
@@ -1,0 +1,36 @@
+package stackerr
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+type StackErr struct {
+	cause error
+	stack []byte
+}
+
+func NewStackErr(cause error) error {
+	return StackErr{
+		cause: cause,
+		stack: debug.Stack(),
+	}
+}
+
+func NewStackErrf(cause error, f string, args ...any) error {
+	msg := fmt.Sprintf(f, args...)
+	cause = fmt.Errorf(msg+": %w", cause)
+	return NewStackErr(cause)
+}
+
+func (se StackErr) Error() string {
+	return se.cause.Error()
+}
+
+func (se StackErr) Unwrap() error {
+	return se.cause
+}
+
+func (se StackErr) Stack() []byte {
+	return se.stack
+}

--- a/pkg/stackerr/stackerr.go
+++ b/pkg/stackerr/stackerr.go
@@ -1,6 +1,7 @@
 package stackerr
 
 import (
+	"errors"
 	"fmt"
 	"runtime/debug"
 )
@@ -33,4 +34,14 @@ func (se StackErr) Unwrap() error {
 
 func (se StackErr) Stack() []byte {
 	return se.stack
+}
+
+func GetStack(err error) ([]byte, bool) {
+	var s interface {
+		Stack() []byte
+	}
+	if errors.As(err, &s) {
+		return s.Stack(), true
+	}
+	return nil, false
 }

--- a/pkg/stackerr/stackerr_test.go
+++ b/pkg/stackerr/stackerr_test.go
@@ -1,0 +1,43 @@
+package stackerr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStackErr(t *testing.T) {
+	err := assert.AnError
+
+	s, ok := GetStack(err)
+	assert.False(t, ok)
+	assert.Empty(t, s)
+
+	err = NewStackErr(err)
+	assert.Equal(t, assert.AnError.Error(), err.Error())
+
+	s, ok = GetStack(err)
+	assert.True(t, ok)
+	assert.NotEmpty(t, s)
+
+	err = NewStackErr(fmt.Errorf("wrapped error can still get stack: %w", err))
+	s, ok = GetStack(err)
+	assert.True(t, ok)
+	assert.NotEmpty(t, s)
+}
+
+func TestStackErrf(t *testing.T) {
+	err := assert.AnError
+
+	s, ok := GetStack(err)
+	assert.False(t, ok)
+	assert.Empty(t, s)
+
+	err = NewStackErrf(err, "error message %d %s", 1, "a")
+	assert.Equal(t, "error message 1 a: "+assert.AnError.Error(), err.Error())
+
+	s, ok = GetStack(err)
+	assert.True(t, ok)
+	assert.NotEmpty(t, s)
+}


### PR DESCRIPTION
Description
-------------
_I didn't realize before opening this that #617 already addresses this. We can certainly close this if not needed._

Don't depend on the archived github.com/pkg/errors. Instead, implement a thin stack trace error wrapper to accomplish the same thing, and replace all usages with the internal one.

- Fixes #616 
- Include a new stack trace error to preserve stack traces which we previously got from the archived package -- I would argue that it's not worth a third party dependency for this small functionality.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [x] 1.20

How Has This Been Tested?
---------------------------

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

