### PR TITLE
Add text/template functions for manipulating "output" values

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+Thank you for investing your time in contributing to our project!
+
+Read our [Code of Conduct](https://github.com/vektra/mockery/blob/master/CODE_OF_CONDUCT.md) to keep our community approachable and respectable.
+
+## Local development setup
+
+This project uses [Taskfile](https://taskfile.dev/), please see the [Install Taskfile](https://taskfile.dev/installation/) and
+[Taskfile usage documentation](https://taskfile.dev/usage/) for more information.
+
+Once installed, run `task -l` for list of valid targets.
+
+## Working with documentation
+
+We use [mkdocs](https://www.mkdocs.org/) with the [mkdocs-material theme](https://squidfunk.github.io/mkdocs-material/).
+
+To preview the documentation locally, run `task mkdocs.serve`. The task will install the required mkdocs plugins and theme
+and run the mkdocs server with real-time updating/refreshing.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 tasks:
   test:
@@ -22,16 +22,27 @@ tasks:
       - "**/*.go"
     cmds:
       - go fmt ./...
-  
+
   mocks:
     desc: generate mockery mocks
     cmds:
       - go run .
-  
+
   docker:
     desc: build the mockery docker image
     cmds:
       - docker build -t vektra/mockery .
+
+  mkdocs.install:
+    desc: install mkdocs and plugins
+    cmds:
+      - pip install -r docs/requirements.txt
+
+  mkdocs.serve:
+    desc: serve mkdocs locally
+    deps: [mkdocs.install]
+    cmds:
+      - mkdocs serve
 
   lint:
     desc: run all the defined linters
@@ -39,7 +50,7 @@ tasks:
       - "**/*.go"
     cmds:
       - go run github.com/golangci/golangci-lint/cmd/golangci-lint run
-  
+
   test.ci:
     deps: [fmt, lint, mocks, test]
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,7 @@ Please see the [features section](/mockery/features/#packages-configuration) for
     | `dry-run` | :fontawesome-solid-x: | `#!yaml false` | Print the actions that would be taken, but don't perform the actions. |
     | `filename` | :fontawesome-solid-check: | `#!yaml "mock_{{.InterfaceName}}.go"` | The name of the file the mock will reside in. |
     | `inpackage` | :fontawesome-solid-x: | `#!yaml false` | When generating mocks alongside the original interfaces, you must specify `inpackage: True` to inform mockery that the mock is being placed in the same package as the original interface. |
-    | `mockname` | :fontawesome-solid-check: | `#!yaml "Mock{{.InterfaceName}}"` | The name of the generated mock. | 
+    | `mockname` | :fontawesome-solid-check: | `#!yaml "Mock{{.InterfaceName}}"` | The name of the generated mock. |
     | `outpkg` | :fontawesome-solid-check: | `#!yaml "{{.PackageName}}"` | Use `outpkg` to specify the package name of the generated mocks. |
     | `log-level` | :fontawesome-solid-x: | `#!yaml "info"` | Set the level of the logger |
     | [`packages`](/mockery/features/#packages-configuration) | :fontawesome-solid-x: | `#!yaml null` | A dictionary containing configuration describing the packages and interfaces to generate mocks for. |
@@ -89,7 +89,7 @@ Please see the [features section](/mockery/features/#packages-configuration) for
     -------------
 
     #### Template Variables
-    
+
 
     !!! note
         Templated variables are only available when using the `packages` config feature.
@@ -108,3 +108,37 @@ Please see the [features section](/mockery/features/#packages-configuration) for
     | MockName | The name of the mock that will be generated. Note that this is simply the `mockname` configuration variable |
     | PackageName | The name of the package from the original interface |
     | PackagePath | The fully qualified package path of the original interface |
+
+    #### Template functions
+
+    !!! note
+        Templated functions are only available when using the `packages` config feature.
+
+    Template functions allow you to inspect and manipulate template variables.
+
+    All template functions are calling native Go functions under the hood, so signatures and return values matches the Go functions you are probably already familiar with.
+
+    To learn more about the templating syntax, please [see the Go `text/template` documentation](https://pkg.go.dev/text/template)
+
+    * [`contains` string substr](https://pkg.go.dev/strings#Contains)
+    * [`hasPrefix` string prefix](https://pkg.go.dev/strings#HasPrefix)
+    * [`hasSuffix` string suffix](https://pkg.go.dev/strings#HasSuffix)
+    * [`join` elems sep](https://pkg.go.dev/strings#Join)
+    * [`replace` string old new n](https://pkg.go.dev/strings#Replace)
+    * [`replaceAll` string old new](https://pkg.go.dev/strings#ReplaceAll)
+    * [`split` string sep](https://pkg.go.dev/strings#Split)
+    * [`splitAfter` string sep](https://pkg.go.dev/strings#SplitAfter)
+    * [`splitAfterN` string sep n](https://pkg.go.dev/strings#SplitAfterN)
+    * [`trim` string cutset](https://pkg.go.dev/strings#Trim)
+    * [`trimLeft` string cutset](https://pkg.go.dev/strings#TrimLeft)
+    * [`trimPrefix` string prefix](https://pkg.go.dev/strings#TrimPrefix)
+    * [`trimRight` string cutset](https://pkg.go.dev/strings#TrimRight)
+    * [`trimSpace` string](https://pkg.go.dev/strings#TrimSpace)
+    * [`trimSuffix` string suffix](https://pkg.go.dev/strings#TrimSuffix)
+    * [`matchString` pattern](https://pkg.go.dev/regexp#MatchString)
+    * [`quoteMeta` string](https://pkg.go.dev/regexp#QuoteMeta)
+    * [`base` string](https://pkg.go.dev/path/filepath#Base)
+    * [`clean` string](https://pkg.go.dev/path/filepath#Clean)
+    * [`dir` string](https://pkg.go.dev/path/filepath#Dir)
+    * [`expandEnv` string](https://pkg.go.dev/os#ExpandEnv)
+    * [`getenv` string](https://pkg.go.dev/os#Getenv)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,6 @@
-mkdocs-material
-pillow
-cairosvg
+mkdocs
 mkdocs-glightbox
+mkdocs-material
+mkdocs-open-in-new-tab
+cairosvg
+pillow

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,3 +74,4 @@ plugins:
 - glightbox
 - social
 - search
+- open-in-new-tab

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -423,13 +423,7 @@ func (g *Generator) printf(s string, vals ...interface{}) {
 var templates = template.New("base template")
 
 func (g *Generator) printTemplate(data interface{}, templateString string) {
-	tmpl := templates.New(templateString).Funcs(
-		template.FuncMap{
-			"join": strings.Join,
-		},
-	)
-
-	tmpl, err := tmpl.Parse(templateString)
+	tmpl, err := templates.New(templateString).Funcs(templateFuncMap).Parse(templateString)
 	if err != nil {
 		// couldn't compile template
 		panic(err)
@@ -609,7 +603,7 @@ func (p *paramList) FormattedParamNames() string {
 }
 
 func (p *paramList) ReturnNames() []string {
-	var names = make([]string, 0, len(p.Names))
+	names := make([]string, 0, len(p.Names))
 	for i := 0; i < len(p.Names); i++ {
 		names = append(names, fmt.Sprintf("r%d", i))
 	}
@@ -761,7 +755,7 @@ func (_m *{{.MockName}}{{.InstantiatedTypeString}}) {{.FunctionName}}({{join .Pa
 		r{{$idx}} = {{$.RetVariableName}}.Error({{$idx}})
 		{{- else if (index $.Returns.Nilable $idx) -}}
 		if {{$.RetVariableName}}.Get({{$idx}}) != nil {
-			r{{$idx}} = {{$.RetVariableName}}.Get({{$idx}}).({{$typ}})	
+			r{{$idx}} = {{$.RetVariableName}}.Get({{$idx}}).({{$typ}})
 		}
 		{{- else -}}
 		r{{$idx}} = {{$.RetVariableName}}.Get({{$idx}}).({{$typ}})
@@ -803,7 +797,6 @@ func (_m *{{.MockName}}{{ .InstantiatedTypeString }}) EXPECT() *{{.ExpecterName}
 }
 
 func (g *Generator) generateExpecterMethodCall(ctx context.Context, method *Method, params, returns *paramList) {
-
 	data := struct {
 		MockName, ExpecterName string
 		CallStruct             string

--- a/pkg/outputter_test.go
+++ b/pkg/outputter_test.go
@@ -226,7 +226,7 @@ func TestOutputter_Generate(t *testing.T) {
 			ymlContents := fmt.Sprintf(`
 packages:
   %s:
-    config: 
+    config:
       all: True
 `, tt.packagePath)
 			require.NoError(t, confPath.WriteFile([]byte(ymlContents)))


### PR DESCRIPTION
Description
-------------

I thought adding some `text/template` functions to the "outputter" would make for a more flexible and more generic solution to #509 and other "I want my Mocks in an oddly specific path" situations where some light-weight string manipulation is necessary 

Adding `replace` (aka `strings.Replace()` and  `trimPrefix` (aka `strings.TrimPrefix`) template functions to the outputter so that it's easier to manipulate it more freely. 

My personal use case is generating mocks for `internal` packages in a somewhat structured way. #509 doesn't seem to work for me, and ideally, I would want to put manage the path in a more flexible way than initially provided by #509 - so I thought a couple of template functions could support this better without having to implement many different hacks.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X]  New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [X] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [X] 1.20

How Has This Been Tested?
---------------------------

I wanted to put internal mocks in the internal folder but without the additional `internal` path segment.

```yaml
packages:
  ./internal:
    config:
      all: true
      recursive: true
      disable-version-string: true
      dir: 'internal/mocks/{{ trimPrefix .InterfaceDirRelative "internal" }}'
      filename: "{{ .InterfaceName }}.go"
      mockname: "{{ .Mock }}{{ .InterfaceName }}"
      outpkg: "{{ .PackageName }}_mocks"
```

yielding

```
$ find internal/mocks 
internal/mocks
internal/mocks/app
internal/mocks/app/letsgo
internal/mocks/app/letsgo/subcommands
internal/mocks/app/letsgo/subcommands/exec
internal/mocks/app/letsgo/subcommands/exec/TaskRunner.go
```

(without the change, it would have been `internal/mocks/internal/app/letsgo/subcommands/exec/TaskRunner.go`)

It also happens to make #509 much nicer and user-controllable via `replace`

```yaml
packages:
  ./internal:
    config:
      all: true
      recursive: true
      disable-version-string: true
      dir: 'mocks/{{ replace .InterfaceDirRelative "internal/" "internal_/" }}'
      filename: "{{ .InterfaceName }}.go"
      mockname: "{{ .Mock }}{{ .InterfaceName }}"
      outpkg: "{{ .PackageName }}_mocks"
```

yielding 

```
$ find mocks      
mocks
mocks/internal_
mocks/internal_/app
mocks/internal_/app/letsgo
mocks/internal_/app/letsgo/subcommands
mocks/internal_/app/letsgo/subcommands/exec
mocks/internal_/app/letsgo/subcommands/exec/TaskRunner.go
```

Checklist
-----------

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

