### PR TITLE
Simplify generator tests by removing declarations

### DIFF
--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -70,7 +70,6 @@ func (s *GeneratorSuite) checkGenerationWithConfig(
 	// it would require changing Write's signature to accept custom options, specifically to
 	// allow the fragments in preexisting cases. It's assumed that this approximation,
 	// just formatting the source, is sufficient for the needs of the current test styles.
-	var actual []byte
 	actual, fmtErr := format.Source(generator.buf.Bytes())
 	s.Require().NoError(fmtErr)
 
@@ -107,7 +106,6 @@ func (s *GeneratorSuite) checkGenerationRegexWithConfig(
 	// it would require changing Write's signature to accept custom options, specifically to
 	// allow the fragments in preexisting cases. It's assumed that this approximation,
 	// just formatting the source, is sufficient for the needs of the current test styles.
-	var actual []byte
 	actual, fmtErr := format.Source(generator.buf.Bytes())
 	s.Require().NoError(fmtErr)
 
@@ -182,7 +180,6 @@ func (s *GeneratorSuite) TestGeneratorExpecterWithRolledVariadic() {
 	)
 	s.Require().NoError(generator.Generate(s.ctx))
 
-	var actual []byte
 	actual, fmtErr := format.Source(generator.buf.Bytes())
 	s.Require().NoError(fmtErr)
 
@@ -377,7 +374,6 @@ func (s *GeneratorSuite) TestGeneratorVariadicArgsAsOneArg() {
 	)
 	s.Require().NoError(generator.Generate(s.ctx))
 
-	var actual []byte
 	actual, fmtErr := format.Source(generator.buf.Bytes())
 	s.Require().NoError(fmtErr)
 
@@ -578,8 +574,7 @@ func (s *GeneratorSuite) TestGeneratorForStructValueReturn() {
 
 func (s *GeneratorSuite) TestGeneratorForStructWithTag() {
 	// StructTag has back-quote, So can't use raw string literals in this test case.
-	var expected string
-	expected += "*struct {"
+	expected := "*struct {"
 	expected += "FieldC int `json:\"field_c\"`"
 	expected += "FieldD int `json:\"field_d\" xml:\"field_d\"`"
 	expected += "}"


### PR DESCRIPTION
Description
-------------

This PR removes redundant declarations.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [x] 1.20

How Has This Been Tested?
---------------------------

Run `go test ./...`

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

