### PR TITLE
Update docs to automatically fetch latest git relase tag name

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ Visit the [releases page](https://github.com/vektra/mockery/releases) to downloa
 
 Supported, but not recommended: [see wiki page](https://github.com/vektra/mockery/wiki/Installation-Methods#go-install) and [related discussions](https://github.com/vektra/mockery/pull/456).
 
-    go install github.com/vektra/mockery/v2@v2.30.1
+<div id="mockery-install-go-command"></div>
 
 !!! warning
 
@@ -37,3 +37,35 @@ Install through [brew](https://brew.sh/)
     brew install mockery
     brew upgrade mockery
 
+
+<script type="text/javascript">
+
+function insert_installation_command(element_to_override,version){
+    element_to_override.innerHTML=`go install github.com/vektra/mockery/v2@${version}`;
+}
+
+const version_key="/mockery/version";
+const element = document.getElementById('mockery-install-go-command');
+const url = `https://api.github.com/repos/vektra/mockery/releases/latest`;
+
+let version = sessionStorage.getItem(version_key);
+if (version !== null) {
+    insert_installation_command(element,version);
+} else {
+  const request = new Request(url, {
+    method: "GET",
+  });
+
+  fetch(request)
+    .then((response) => response.json())
+    .then((data) => {
+      sessionStorage.setItem(version_key, data.name);
+      insert_installation_command(element,data.name);
+    })
+    .catch((error) =>{
+          console.error(error);
+          element.innerHTML=`failed to fetch latest release info from: https://api.github.com/repos/vektra/mockery/releases/latest`;
+    }
+  );
+}
+</script>


### PR DESCRIPTION

Description
-------------

installation docs will fetch latest release tag 
from github api and injei into it into go install command
it will also cache it in the session storage to not fetch it again in the same session.
similar to how [mkdocs-materials](https://github.com/squidfunk/mkdocs-material/blob/5dc59980317d7ab54a9f9a0a554aec794058c9ff/src/assets/javascripts/components/source/facts/github/index.ts#L60) get the latest tag info


- Fixes #642 



- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [ ] 1.20

How Has This Been Tested?
---------------------------
built and served the docs,refreshed the site and got the expected tag.
when there wasnt network connectivity got the expected error.

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

