### PR TITLE
Add error log for unsupported config

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,5 +1,4 @@
 quiet: False
-keeptree: True
 disable-version-string: True
 with-expecter: True
 mockname: "{{.InterfaceName}}"

--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -54,7 +54,7 @@ func NewRootCmd() *cobra.Command {
 	pFlags.StringVar(&cfgFile, "config", "", "config file to use")
 	pFlags.String("name", "", "name or matching regular expression of interface to generate mock for")
 	pFlags.Bool("print", false, "print the generated mock to stdout")
-	pFlags.String("output", "./mocks", "directory to write mocks to")
+	pFlags.String("output", "", "directory to write mocks to")
 	pFlags.String("outpkg", "mocks", "name of generated package")
 	pFlags.String("packageprefix", "", "prefix for the generated package name, it is ignored if outpkg is also specified.")
 	pFlags.String("dir", "", "directory to search for interfaces")
@@ -64,7 +64,7 @@ func NewRootCmd() *cobra.Command {
 	pFlags.Bool("inpackage", false, "generate a mock that goes inside the original package")
 	pFlags.Bool("inpackage-suffix", false, "use filename '_mock' suffix instead of 'mock_' prefix for InPackage mocks")
 	pFlags.Bool("testonly", false, "generate a mock in a _test.go file")
-	pFlags.String("case", "camel", "name the mocked file using casing convention [camel, snake, underscore]")
+	pFlags.String("case", "", "name the mocked file using casing convention [camel, snake, underscore]")
 	pFlags.String("note", "", "comment to insert into prologue of each generated file")
 	pFlags.String("cpuprofile", "", "write cpu profile to file")
 	pFlags.Bool("version", false, "prints the installed version of mockery")
@@ -230,7 +230,9 @@ func (r *RootApp) Run() error {
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to determine configured packages: %w", err)
 	}
-	if len(configuredPackages) != 0 && r.Config.Name == "" {
+	if len(configuredPackages) != 0 {
+		r.Config.LogUnsupportedPackagesConfig(ctx)
+
 		configuredPackages, err := r.Config.GetPackages(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to get package from config: %w", err)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -700,18 +700,9 @@ func TestNewConfigFromViper(t *testing.T) {
 				return viper.New()
 			},
 			want: &Config{
-				Dir: ".",
-			},
-		},
-		{
-			name: "dir set",
-			v: func(t *testing.T) *viper.Viper {
-				v := viper.New()
-				v.Set("dir", "foobar")
-				return v
-			},
-			want: &Config{
-				Dir: "foobar",
+				Case:   "camel",
+				Dir:    ".",
+				Output: "./mocks",
 			},
 		},
 		{

--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -320,6 +320,8 @@ func (m *Outputter) Generate(ctx context.Context, iface *Interface) error {
 	}
 
 	for _, interfaceConfig := range interfaceConfigs {
+		interfaceConfig.LogUnsupportedPackagesConfig(ctx)
+
 		log.Debug().Msg("getting mock generator")
 
 		if err := parseConfigTemplates(ctx, interfaceConfig, iface); err != nil {


### PR DESCRIPTION
Description
-------------

This commit will log an error message if unsupported config is being used. I have chosen not to cause mockery to return an error code because it's possible that configs using unsupported parameters are working just fine, so we don't want to break those users. Instead, the log message should hopefully get their attention, and the attention of anyone trying to migrate to packages. Also removed is the conditional used to enter into the `packages` code path. Previously it asserted that `Config.Name == ""` but this was causing more confusion than it needed to.

This fixes #685

<img width="963" alt="Screenshot 2023-08-04 at 3 33 36 PM" src="https://github.com/vektra/mockery/assets/11232769/e5f5f49e-1c8c-41ad-b54a-53205e28fbb5">

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [x] 1.20

How Has This Been Tested?
---------------------------

Manual tests

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

