### PR TITLE
Add gcc to docker for projects with cgo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.20-alpine as builder
 
+RUN apk --update add --no-cache gcc musl-dev
+
 COPY mockery /usr/local/bin
 
 # Explicitly set a writable cache path when running --user=$(id -u):$(id -g)


### PR DESCRIPTION
Description
-------------

My project has dependency [h3-go](https://github.com/uber/h3-go), which use CGO.
When I use mockery in Docker I get an error `ERR encountered error when loading package error="...: undefined: h3geo.H3Index"`
Since [Go1.20](https://tip.golang.org/doc/go1.20#go-command) the binary doesn't include pre-compiled package archives for the standard library

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [x] 1.20

How Has This Been Tested?
---------------------------

Build Docker with mockery:
```dockerfile
FROM golang:1.20-alpine as builder

WORKDIR /app
COPY . .
RUN go build -o mockery .

FROM golang:1.20-alpine

# without this line mockery will fail
RUN apk --update add --no-cache gcc musl-dev

COPY --from=builder /app/mockery /usr/local/bin

# Explicitly set a writable cache path when running --user=$(id -u):$(id -g)
# see: https://github.com/golang/go/issues/26280#issuecomment-445294378
ENV GOCACHE /tmp/.cache

ENTRYPOINT ["/usr/local/bin/mockery"]
```

Code example:
```golang
package tmp

import h3geo "github.com/uber/h3-go/v3"

type H3 interface {
	Calculate(h3geo.H3Index)
}
```

Mockery configuration:
```yaml
with-expecter: true
packages:
  go-example/tmp:
    interfaces:
      H3:
```

Run command: `docker run --volume $(pwd):/app --workdir /app vektra/mockery:latest`

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

