### PR TITLE
Allow setting ExpectedCalls on mock constructor

### DIFF
--- a/mocks/github.com/vektra/mockery/v2/pkg/TypesPackage.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/TypesPackage.go
@@ -104,9 +104,10 @@ func (_c *TypesPackage_Path_Call) RunAndReturn(run func() string) *TypesPackage_
 func NewTypesPackage(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *TypesPackage {
+}, expectedCalls ...*mock.Call) *TypesPackage {
 	mock := &TypesPackage{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/A.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/A.go
@@ -76,9 +76,10 @@ func (_c *A_Call_Call) RunAndReturn(run func() (test.B, error)) *A_Call_Call {
 func NewA(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *A {
+}, expectedCalls ...*mock.Call) *A {
 	mock := &A{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/AsyncProducer.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/AsyncProducer.go
@@ -151,9 +151,10 @@ func (_c *AsyncProducer_Whatever_Call) RunAndReturn(run func() chan bool) *Async
 func NewAsyncProducer(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *AsyncProducer {
+}, expectedCalls ...*mock.Call) *AsyncProducer {
 	mock := &AsyncProducer{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Blank.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Blank.go
@@ -64,9 +64,10 @@ func (_c *Blank_Create_Call) RunAndReturn(run func(interface{}) error) *Blank_Cr
 func NewBlank(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *Blank {
+}, expectedCalls ...*mock.Call) *Blank {
 	mock := &Blank{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/ConsulLock.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/ConsulLock.go
@@ -117,9 +117,10 @@ func (_c *ConsulLock_Unlock_Call) RunAndReturn(run func() error) *ConsulLock_Unl
 func NewConsulLock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *ConsulLock {
+}, expectedCalls ...*mock.Call) *ConsulLock {
 	mock := &ConsulLock{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/EmbeddedGet.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/EmbeddedGet.go
@@ -66,9 +66,10 @@ func (_c *EmbeddedGet_Get_Call[T]) RunAndReturn(run func() T) *EmbeddedGet_Get_C
 func NewEmbeddedGet[T constraints.Signed](t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *EmbeddedGet[T] {
+}, expectedCalls ...*mock.Call) *EmbeddedGet[T] {
 	mock := &EmbeddedGet[T]{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Example.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Example.go
@@ -113,9 +113,10 @@ func (_c *Example_B_Call) RunAndReturn(run func(string) fixtureshttp.MyStruct) *
 func NewExample(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *Example {
+}, expectedCalls ...*mock.Call) *Example {
 	mock := &Example{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Expecter.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Expecter.go
@@ -260,9 +260,10 @@ func (_c *Expecter_VariadicMany_Call) RunAndReturn(run func(int, string, ...inte
 func NewExpecter(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *Expecter {
+}, expectedCalls ...*mock.Call) *Expecter {
 	mock := &Expecter{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/ExpecterAndRolledVariadic.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/ExpecterAndRolledVariadic.go
@@ -265,9 +265,10 @@ func (_c *ExpecterAndRolledVariadic_VariadicMany_Call) RunAndReturn(run func(int
 func NewExpecterAndRolledVariadic(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *ExpecterAndRolledVariadic {
+}, expectedCalls ...*mock.Call) *ExpecterAndRolledVariadic {
 	mock := &ExpecterAndRolledVariadic{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Fooer.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Fooer.go
@@ -141,9 +141,10 @@ func (_c *Fooer_Foo_Call) RunAndReturn(run func(func(string) string) error) *Foo
 func NewFooer(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *Fooer {
+}, expectedCalls ...*mock.Call) *Fooer {
 	mock := &Fooer{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/FuncArgsCollision.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/FuncArgsCollision.go
@@ -64,9 +64,10 @@ func (_c *FuncArgsCollision_Foo_Call) RunAndReturn(run func(interface{}) error) 
 func NewFuncArgsCollision(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *FuncArgsCollision {
+}, expectedCalls ...*mock.Call) *FuncArgsCollision {
 	mock := &FuncArgsCollision{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/GetGeneric.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/GetGeneric.go
@@ -66,9 +66,10 @@ func (_c *GetGeneric_Get_Call[T]) RunAndReturn(run func() T) *GetGeneric_Get_Cal
 func NewGetGeneric[T constraints.Integer](t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *GetGeneric[T] {
+}, expectedCalls ...*mock.Call) *GetGeneric[T] {
 	mock := &GetGeneric[T]{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/GetInt.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/GetInt.go
@@ -63,9 +63,10 @@ func (_c *GetInt_Get_Call) RunAndReturn(run func() int) *GetInt_Get_Call {
 func NewGetInt(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *GetInt {
+}, expectedCalls ...*mock.Call) *GetInt {
 	mock := &GetInt{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/HasConflictingNestedImports.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/HasConflictingNestedImports.go
@@ -121,9 +121,10 @@ func (_c *HasConflictingNestedImports_Z_Call) RunAndReturn(run func() fixturesht
 func NewHasConflictingNestedImports(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *HasConflictingNestedImports {
+}, expectedCalls ...*mock.Call) *HasConflictingNestedImports {
 	mock := &HasConflictingNestedImports{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/ImportsSameAsPackage.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/ImportsSameAsPackage.go
@@ -144,9 +144,10 @@ func (_c *ImportsSameAsPackage_C_Call) RunAndReturn(run func(fixtures.C)) *Impor
 func NewImportsSameAsPackage(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *ImportsSameAsPackage {
+}, expectedCalls ...*mock.Call) *ImportsSameAsPackage {
 	mock := &ImportsSameAsPackage{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/KeyManager.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/KeyManager.go
@@ -82,9 +82,10 @@ func (_c *KeyManager_GetKey_Call) RunAndReturn(run func(string, uint16) ([]byte,
 func NewKeyManager(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *KeyManager {
+}, expectedCalls ...*mock.Call) *KeyManager {
 	mock := &KeyManager{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/MapFunc.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/MapFunc.go
@@ -64,9 +64,10 @@ func (_c *MapFunc_Get_Call) RunAndReturn(run func(map[string]func(string) string
 func NewMapFunc(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MapFunc {
+}, expectedCalls ...*mock.Call) *MapFunc {
 	mock := &MapFunc{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/MapToInterface.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/MapToInterface.go
@@ -68,9 +68,10 @@ func (_c *MapToInterface_Foo_Call) RunAndReturn(run func(...map[string]interface
 func NewMapToInterface(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MapToInterface {
+}, expectedCalls ...*mock.Call) *MapToInterface {
 	mock := &MapToInterface{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/MyReader.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/MyReader.go
@@ -74,9 +74,10 @@ func (_c *MyReader_Read_Call) RunAndReturn(run func([]byte) (int, error)) *MyRea
 func NewMyReader(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MyReader {
+}, expectedCalls ...*mock.Call) *MyReader {
 	mock := &MyReader{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Requester.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Requester.go
@@ -74,9 +74,10 @@ func (_c *Requester_Get_Call) RunAndReturn(run func(string) (string, error)) *Re
 func NewRequester(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *Requester {
+}, expectedCalls ...*mock.Call) *Requester {
 	mock := &Requester{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Requester2.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Requester2.go
@@ -64,9 +64,10 @@ func (_c *Requester2_Get_Call) RunAndReturn(run func(string) error) *Requester2_
 func NewRequester2(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *Requester2 {
+}, expectedCalls ...*mock.Call) *Requester2 {
 	mock := &Requester2{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Requester3.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Requester3.go
@@ -63,9 +63,10 @@ func (_c *Requester3_Get_Call) RunAndReturn(run func() error) *Requester3_Get_Ca
 func NewRequester3(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *Requester3 {
+}, expectedCalls ...*mock.Call) *Requester3 {
 	mock := &Requester3{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Requester4.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Requester4.go
@@ -54,9 +54,10 @@ func (_c *Requester4_Get_Call) RunAndReturn(run func()) *Requester4_Get_Call {
 func NewRequester4(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *Requester4 {
+}, expectedCalls ...*mock.Call) *Requester4 {
 	mock := &Requester4{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterArgSameAsImport.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterArgSameAsImport.go
@@ -70,9 +70,10 @@ func (_c *RequesterArgSameAsImport_Get_Call) RunAndReturn(run func(string) *json
 func NewRequesterArgSameAsImport(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *RequesterArgSameAsImport {
+}, expectedCalls ...*mock.Call) *RequesterArgSameAsImport {
 	mock := &RequesterArgSameAsImport{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterArgSameAsNamedImport.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterArgSameAsNamedImport.go
@@ -70,9 +70,10 @@ func (_c *RequesterArgSameAsNamedImport_Get_Call) RunAndReturn(run func(string) 
 func NewRequesterArgSameAsNamedImport(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *RequesterArgSameAsNamedImport {
+}, expectedCalls ...*mock.Call) *RequesterArgSameAsNamedImport {
 	mock := &RequesterArgSameAsNamedImport{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterArgSameAsPkg.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterArgSameAsPkg.go
@@ -55,9 +55,10 @@ func (_c *RequesterArgSameAsPkg_Get_Call) RunAndReturn(run func(string)) *Reques
 func NewRequesterArgSameAsPkg(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *RequesterArgSameAsPkg {
+}, expectedCalls ...*mock.Call) *RequesterArgSameAsPkg {
 	mock := &RequesterArgSameAsPkg{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterArray.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterArray.go
@@ -76,9 +76,10 @@ func (_c *RequesterArray_Get_Call) RunAndReturn(run func(string) ([2]string, err
 func NewRequesterArray(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *RequesterArray {
+}, expectedCalls ...*mock.Call) *RequesterArray {
 	mock := &RequesterArray{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterElided.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterElided.go
@@ -65,9 +65,10 @@ func (_c *RequesterElided_Get_Call) RunAndReturn(run func(string, string) error)
 func NewRequesterElided(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *RequesterElided {
+}, expectedCalls ...*mock.Call) *RequesterElided {
 	mock := &RequesterElided{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterGenerics.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterGenerics.go
@@ -197,9 +197,10 @@ func NewRequesterGenerics[TAny interface{}, TComparable comparable, TSigned cons
 }](t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *RequesterGenerics[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
+}, expectedCalls ...*mock.Call) *RequesterGenerics[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
 	mock := &RequesterGenerics[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterIface.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterIface.go
@@ -69,9 +69,10 @@ func (_c *RequesterIface_Get_Call) RunAndReturn(run func() io.Reader) *Requester
 func NewRequesterIface(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *RequesterIface {
+}, expectedCalls ...*mock.Call) *RequesterIface {
 	mock := &RequesterIface{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterNS.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterNS.go
@@ -78,9 +78,10 @@ func (_c *RequesterNS_Get_Call) RunAndReturn(run func(string) (http.Response, er
 func NewRequesterNS(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *RequesterNS {
+}, expectedCalls ...*mock.Call) *RequesterNS {
 	mock := &RequesterNS{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterPtr.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterPtr.go
@@ -76,9 +76,10 @@ func (_c *RequesterPtr_Get_Call) RunAndReturn(run func(string) (*string, error))
 func NewRequesterPtr(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *RequesterPtr {
+}, expectedCalls ...*mock.Call) *RequesterPtr {
 	mock := &RequesterPtr{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterReturnElided.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterReturnElided.go
@@ -140,9 +140,10 @@ func (_c *RequesterReturnElided_Put_Call) RunAndReturn(run func(string) (int, er
 func NewRequesterReturnElided(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *RequesterReturnElided {
+}, expectedCalls ...*mock.Call) *RequesterReturnElided {
 	mock := &RequesterReturnElided{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterSlice.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterSlice.go
@@ -76,9 +76,10 @@ func (_c *RequesterSlice_Get_Call) RunAndReturn(run func(string) ([]string, erro
 func NewRequesterSlice(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *RequesterSlice {
+}, expectedCalls ...*mock.Call) *RequesterSlice {
 	mock := &RequesterSlice{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterVariadic.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterVariadic.go
@@ -92,9 +92,10 @@ func (_m *RequesterVariadic) Sprintf(format string, a ...interface{}) string {
 func NewRequesterVariadic(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *RequesterVariadic {
+}, expectedCalls ...*mock.Call) *RequesterVariadic {
 	mock := &RequesterVariadic{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterVariadicOneArgument.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterVariadicOneArgument.go
@@ -74,9 +74,10 @@ func (_m *RequesterVariadicOneArgument) Sprintf(format string, a ...interface{})
 func NewRequesterVariadicOneArgument(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *RequesterVariadicOneArgument {
+}, expectedCalls ...*mock.Call) *RequesterVariadicOneArgument {
 	mock := &RequesterVariadicOneArgument{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/SendFunc.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/SendFunc.go
@@ -79,9 +79,10 @@ func (_c *SendFunc_Execute_Call) RunAndReturn(run func(context.Context, string) 
 func NewSendFunc(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *SendFunc {
+}, expectedCalls ...*mock.Call) *SendFunc {
 	mock := &SendFunc{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Sibling.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Sibling.go
@@ -54,9 +54,10 @@ func (_c *Sibling_DoSomething_Call) RunAndReturn(run func()) *Sibling_DoSomethin
 func NewSibling(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *Sibling {
+}, expectedCalls ...*mock.Call) *Sibling {
 	mock := &Sibling{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/StructWithTag.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/StructWithTag.go
@@ -99,9 +99,10 @@ func (_c *StructWithTag_MethodA_Call) RunAndReturn(run func(*struct {
 func NewStructWithTag(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *StructWithTag {
+}, expectedCalls ...*mock.Call) *StructWithTag {
 	mock := &StructWithTag{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/UnsafeInterface.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/UnsafeInterface.go
@@ -59,9 +59,10 @@ func (_c *UnsafeInterface_Do_Call) RunAndReturn(run func(*unsafe.Pointer)) *Unsa
 func NewUnsafeInterface(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *UnsafeInterface {
+}, expectedCalls ...*mock.Call) *UnsafeInterface {
 	mock := &UnsafeInterface{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/UsesOtherPkgIface.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/UsesOtherPkgIface.go
@@ -58,9 +58,10 @@ func (_c *UsesOtherPkgIface_DoSomethingElse_Call) RunAndReturn(run func(test.Sib
 func NewUsesOtherPkgIface(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *UsesOtherPkgIface {
+}, expectedCalls ...*mock.Call) *UsesOtherPkgIface {
 	mock := &UsesOtherPkgIface{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/requester_unexported.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/requester_unexported.go
@@ -54,9 +54,10 @@ func (_c *requester_unexported_Get_Call) RunAndReturn(run func()) *requester_une
 func newRequester_unexported(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *requester_unexported {
+}, expectedCalls ...*mock.Call) *requester_unexported {
 	mock := &requester_unexported{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/pkg/fixtures/method_args/same_name_arg_and_type/mock_interfaceA_test.go
+++ b/pkg/fixtures/method_args/same_name_arg_and_type/mock_interfaceA_test.go
@@ -154,9 +154,10 @@ func (_c *interfaceAMock_DoB0v2_Call) RunAndReturn(run func(interfaceB0) interfa
 func newInterfaceAMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *interfaceAMock {
+}, expectedCalls ...*mock.Call) *interfaceAMock {
 	mock := &interfaceAMock{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/pkg/fixtures/method_args/same_name_arg_and_type/mock_interfaceB0_test.go
+++ b/pkg/fixtures/method_args/same_name_arg_and_type/mock_interfaceB0_test.go
@@ -66,9 +66,10 @@ func (_c *interfaceB0Mock_DoB0_Call) RunAndReturn(run func(interfaceB0) interfac
 func newInterfaceB0Mock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *interfaceB0Mock {
+}, expectedCalls ...*mock.Call) *interfaceB0Mock {
 	mock := &interfaceB0Mock{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/pkg/fixtures/method_args/same_name_arg_and_type/mock_interfaceB_test.go
+++ b/pkg/fixtures/method_args/same_name_arg_and_type/mock_interfaceB_test.go
@@ -63,9 +63,10 @@ func (_c *interfaceBMock_GetData_Call) RunAndReturn(run func() int) *interfaceBM
 func newInterfaceBMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *interfaceBMock {
+}, expectedCalls ...*mock.Call) *interfaceBMock {
 	mock := &interfaceBMock{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/pkg/fixtures/recursive_generation/Foo_mock.go
+++ b/pkg/fixtures/recursive_generation/Foo_mock.go
@@ -63,9 +63,10 @@ func (_c *MockFoo_Get_Call) RunAndReturn(run func() string) *MockFoo_Get_Call {
 func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockFoo {
+}, expectedCalls ...*mock.Call) *MockFoo {
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/pkg/fixtures/recursive_generation/subpkg1/Foo_mock.go
+++ b/pkg/fixtures/recursive_generation/subpkg1/Foo_mock.go
@@ -63,9 +63,10 @@ func (_c *MockFoo_Get_Call) RunAndReturn(run func() string) *MockFoo_Get_Call {
 func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockFoo {
+}, expectedCalls ...*mock.Call) *MockFoo {
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/pkg/fixtures/recursive_generation/subpkg2/Foo_mock.go
+++ b/pkg/fixtures/recursive_generation/subpkg2/Foo_mock.go
@@ -63,9 +63,10 @@ func (_c *MockFoo_Get_Call) RunAndReturn(run func() string) *MockFoo_Get_Call {
 func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockFoo {
+}, expectedCalls ...*mock.Call) *MockFoo {
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/pkg/fixtures/recursive_generation/subpkg_with_only_autogenerated_files/Foo_mock.go
+++ b/pkg/fixtures/recursive_generation/subpkg_with_only_autogenerated_files/Foo_mock.go
@@ -63,9 +63,10 @@ func (_c *MockFoo_Get_Call) RunAndReturn(run func() string) *MockFoo_Get_Call {
 func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockFoo {
+}, expectedCalls ...*mock.Call) *MockFoo {
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -893,9 +893,10 @@ func (g *Generator) generateConstructor(ctx context.Context) {
 func {{ .ConstructorName }}{{ .TypeConstraint }}(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *{{ .MockName }}{{ .InstantiatedTypeString }} {
+}, expectedCalls ...*mock.Call) *{{ .MockName }}{{ .InstantiatedTypeString }} {
 	mock := &{{ .MockName }}{{ .InstantiatedTypeString }}{}
 	mock.Mock.Test(t)
+	mock.Mock.ExpectedCalls = expectedCalls
 
 	t.Cleanup(func() { mock.AssertExpectations(t) })
 


### PR DESCRIPTION
Description
-------------

The proposed change makes the following possible on the test in the linked issue:
```golang
uc := users_mock.NewClient(t, tt.userMocks...)
``` 

This makes the test more readable and makes the mockery implementation of an interface easier to use in table driven tests.

This is my first attempt at an open source contribution, so I'm happy to update any code styles or follow a maintainer's lead on how to best implement this change.

Closes #696 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [x] 1.20

How Has This Been Tested?
---------------------------

I used the new constructor signature to write the unit test above (the test passed). I've also updated the `mocks/` directory to include the new constructor signature in the generated code test files.

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

