### PR TITLE
Support "exclude" in package config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -599,7 +599,7 @@ func (c *Config) discoverRecursivePackages(ctx context.Context) error {
 				p := pathlib.NewPath(subPkg)
 				relativePath, err := p.RelativeToStr(pkgPath)
 				if err != nil {
-					return fmt.Errorf("failed to get path for %s relative to %s: %w", subPkg, pkgPath, err)
+					return stackerr.NewStackErrf(err, "failed to get path for %s relative to %s", subPkg, pkgPath)
 				}
 				if conf.ExcludePath(relativePath.String()) {
 					subPkgLog.Info().Msg("subpackage is excluded")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -595,6 +595,18 @@ func (c *Config) discoverRecursivePackages(ctx context.Context) error {
 			subPkgLog := pkgLog.With().Str("sub-package", subPkg).Logger()
 			subPkgCtx := subPkgLog.WithContext(pkgCtx)
 
+			if len(conf.Exclude) > 0 {
+				p := pathlib.NewPath(subPkg)
+				relativePath, err := p.RelativeToStr(pkgPath)
+				if err != nil {
+					return fmt.Errorf("failed to get path for %s relative to %s: %w", subPkg, pkgPath, err)
+				}
+				if conf.ExcludePath(relativePath.String()) {
+					subPkgLog.Info().Msg("subpackage is excluded")
+					continue
+				}
+			}
+
 			subPkgLog.Debug().Msg("adding sub-package config")
 			if err := c.addSubPkgConfig(subPkgCtx, subPkg, pkgPath); err != nil {
 				subPkgLog.Err(err).Msg("failed to add sub-package config")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -982,6 +982,33 @@ packages:
 with-expecter: false
 `,
 		},
+		{
+			name: "test with excluded subpackage",
+			cfgYaml: `
+with-expecter: False
+dir: foobar
+packages:
+  github.com/vektra/mockery/v2/pkg/fixtures/example_project/pkg_with_subpkgs/subpkg2:
+    config:
+      recursive: True
+      with-expecter: True
+      all: True
+      exclude:
+        - subpkg3
+`,
+			wantCfgMap: `dir: foobar
+packages:
+    github.com/vektra/mockery/v2/pkg/fixtures/example_project/pkg_with_subpkgs/subpkg2:
+        config:
+            all: true
+            dir: foobar
+            exclude:
+                - subpkg3
+            recursive: true
+            with-expecter: true
+with-expecter: false
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Description
-------------

This PR recognizes the "exclude" directive in a package configuration. The following configuration snippet now excludes the "client/common" directory (and everything therein):

```yaml
---
with-expecter: False
filename: "{{.InterfaceName}}.go"
include-auto-generated: false
mockname: "{{.InterfaceName}}"
outpkg: "mocks"
packages:
  github.com/organization/reponame/core/clients:
    config:
      all: true
      dir: mocks/{{ .InterfaceDirRelative }}
      recursive: true
      exclude:
        - common
```

This is motivated by errors we get from mockery arising from imports in `github.com/organization/reponame/core/clients/common`. We want to be able to use the recursive functionality (since we have a bunch of different clients) but skip the one directory that has only test helpers and no interfaces to mock. The "exclude" feature lets us do that in the old style configuration format, but there was no implementation of this in the new packages format.

Fixes https://github.com/vektra/mockery/issues/708

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [x] 1.20

How Has This Been Tested?
---------------------------

Added a unit test to the existing table driven test that exercises the revised functionality. (It may look a bit strange to add a stanza where the input YAML equals the output YAML. However without the change in the code, the output YAML would be auto-populated with the information about `subpkg3`).

Tested in our use case, as running `mockery` against our configuration (represented by the YAML snippet above) correctly logs that it is skipping the subpackage and exits without error.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Regarding documentation updates: `exclude` is in the table of deprecated parameters for v3. I am hoping that this use case allows it to be brought back.