### PR TITLE
Fix replace-type for different packages from the same source

### DIFF
--- a/pkg/fixtures/example_project/replace_type/README.md
+++ b/pkg/fixtures/example_project/replace_type/README.md
@@ -1,0 +1,9 @@
+## Fix replace-type for different packages from the same source
+
+[Issue 710](https://github.com/vektra/mockery/pull/710)
+
+This package is used to test the case where multiple types come from the same package (`replace_type/rti/internal`),
+but results in types in different packages (`replace_type/rt1` and `replace_type/rt2`).
+
+Tests `TestReplaceTypePackageMultiplePrologue` and `TestReplaceTypePackageMultiple` use it to check if this outputs
+the correct import and type names.

--- a/pkg/fixtures/example_project/replace_type/rt.go
+++ b/pkg/fixtures/example_project/replace_type/rt.go
@@ -1,0 +1,11 @@
+package replace_type
+
+import (
+	"github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/rt1"
+	"github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/rt2"
+)
+
+type RType interface {
+	Replace1(f rt1.RType1)
+	Replace2(f rt2.RType2)
+}

--- a/pkg/fixtures/example_project/replace_type/rti/internal/rti.go
+++ b/pkg/fixtures/example_project/replace_type/rti/internal/rti.go
@@ -1,0 +1,9 @@
+package internal
+
+type RTInternal1 struct {
+	A int
+}
+
+type RTInternal2 struct {
+	B string
+}

--- a/pkg/fixtures/example_project/replace_type/rti/rt1/rt1.go
+++ b/pkg/fixtures/example_project/replace_type/rti/rt1/rt1.go
@@ -1,0 +1,5 @@
+package rt1
+
+import "github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/internal"
+
+type RType1 = internal.RTInternal1

--- a/pkg/fixtures/example_project/replace_type/rti/rt2/rt2.go
+++ b/pkg/fixtures/example_project/replace_type/rti/rt2/rt2.go
@@ -1,0 +1,5 @@
+package rt2
+
+import "github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/internal"
+
+type RType2 = internal.RTInternal2

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -711,6 +711,44 @@ func (s *GeneratorSuite) TestReplaceTypePackage() {
 	})
 }
 
+func (s *GeneratorSuite) TestReplaceTypePackageMultiplePrologue() {
+	expected := `package mocks
+
+import mock "github.com/stretchr/testify/mock"
+import replace_type "github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type"
+import rt1 "github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/rt1"
+import rt2 "github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/rt2"
+
+`
+	generator := NewGenerator(
+		s.ctx,
+		GeneratorConfig{InPackage: false, ReplaceType: []string{
+			"github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/internal.RTInternal1=rt1:github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/rt1.RType1",
+			"github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/internal.RTInternal2=rt2:github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/rt2.RType2",
+		}},
+		s.getInterfaceFromFile("example_project/replace_type/rt.go", "RType"),
+		pkg,
+	)
+
+	s.checkPrologueGeneration(generator, expected)
+}
+
+func (s *GeneratorSuite) TestReplaceTypePackageMultiple() {
+	cfg := GeneratorConfig{InPackage: false, ReplaceType: []string{
+		// first one will be ignored by the more specific ones
+		"github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/internal=fiz3:github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/rt3",
+		"github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/internal.RTInternal1=rt1:github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/rt1.RType1",
+		"github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/internal.RTInternal2=rt2:github.com/vektra/mockery/v2/pkg/fixtures/example_project/replace_type/rti/rt2.RType2",
+	}}
+
+	s.checkGenerationRegexWithConfig("example_project/replace_type/rt.go", "RType", cfg, []regexpExpected{
+		// func (_m *RType) Replace1(f rt1.RType1)
+		{true, regexp.MustCompile(`func \([^\)]+\) Replace1\(f rt1\.RType1`)},
+		// func (_m *RType) Replace2(f rt2.RType2)
+		{true, regexp.MustCompile(`func \([^\)]+\) Replace2\(f rt2\.RType2`)},
+	})
+}
+
 func (s *GeneratorSuite) TestGenericGenerator() {
 	s.checkGeneration("generic.go", "RequesterGenerics", false, "", "")
 }


### PR DESCRIPTION
Description
-------------

When different packages that map to the same source package and mapped with replace-type, the package of the first one are used for all other packages.

- Fixes #688

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [ ] 1.20
- [x] 1.21

How Has This Been Tested?
---------------------------

- a test was added for this specific problem.
- @rkoehl05 was able to validate the solution in his mock repo.

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

