### PR TITLE
Dockerfile: up go version to 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 
 RUN apk --update add --no-cache gcc musl-dev
 


### PR DESCRIPTION
Description
-------------

Currently using mockery via docker does not work on projects using go 1.22.

An example of the error is:

```
err: exit status 1: stderr: go: go.mod requires go >= 1.22 (running go 1.21.7; GOTOOLCHAIN=local)

09 Feb 24 10:19 UTC ERR unable to parse packages error="err: exit status 1: stderr: go: go.mod requires go >= 1.22 (running go 1.21.7; GOTOOLCHAIN=local)\n" dry-run=false version=v2.40.2
```

This happens because the go version in the Dockerfile is go 1.21.

This change upgrades the go version in the Dockerfile to use go 1.22, allowing the 

- Fixes #754 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [ ] 1.20
- [x] 1.22

How Has This Been Tested?
---------------------------

I have built and run the docker locally

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

