### PR TITLE
add option package suffix and unit tests

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -57,6 +57,7 @@ func NewRootCmd() *cobra.Command {
 	pFlags.String("output", "", "directory to write mocks to")
 	pFlags.String("outpkg", "mocks", "name of generated package")
 	pFlags.String("packageprefix", "", "prefix for the generated package name, it is ignored if outpkg is also specified.")
+	pFlags.String("packagesuffix", "", "suffix for the generated package name, it is ignored if outpkg is also specified.")
 	pFlags.String("dir", "", "directory to search for interfaces")
 	pFlags.BoolP("recursive", "r", false, "recurse search into sub-directories")
 	pFlags.StringArray("exclude", nil, "prefixes of subdirectories and files to exclude from search")
@@ -380,6 +381,7 @@ func (r *RootApp) Run() error {
 		MockBuildTags:        r.Config.MockBuildTags,
 		PackageName:          r.Config.Outpkg,
 		PackageNamePrefix:    r.Config.Packageprefix,
+		PackageNameSuffix:    r.Config.Packagesuffix,
 		StructName:           r.Config.StructName,
 		UnrollVariadic:       r.Config.UnrollVariadic,
 		WithExpecter:         r.Config.WithExpecter,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	Output               string                 `mapstructure:"output"`
 	Packages             map[string]interface{} `mapstructure:"packages"`
 	Packageprefix        string                 `mapstructure:"packageprefix"`
+	Packagesuffix        string                 `mapstructure:"packagesuffix"`
 	Print                bool                   `mapstructure:"print"`
 	Profile              string                 `mapstructure:"profile"`
 	Quiet                bool                   `mapstructure:"quiet"`

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -32,6 +32,7 @@ func DetermineOutputPackageName(
 	interfacePackageName string,
 	packageNamePrefix string,
 	packageName string,
+	packageNameSuffix string,
 	keepTree bool,
 	inPackage bool,
 ) string {
@@ -41,9 +42,9 @@ func DetermineOutputPackageName(
 		pkg = filepath.Dir(interfaceFileName)
 	} else if inPackage {
 		pkg = filepath.Dir(interfaceFileName)
-	} else if (packageName == "" || packageName == "mocks") && packageNamePrefix != "" {
+	} else if (packageName == "" || packageName == "mocks") && (packageNamePrefix != "" || packageNameSuffix != "") {
 		// go with package name prefix only when package name is empty or default and package name prefix is specified
-		pkg = fmt.Sprintf("%s%s", packageNamePrefix, interfacePackageName)
+		pkg = fmt.Sprintf("%s%s%s", packageNamePrefix, interfacePackageName, packageNameSuffix)
 	} else {
 		pkg = packageName
 	}
@@ -60,6 +61,7 @@ type GeneratorConfig struct {
 	MockBuildTags        string
 	PackageName          string
 	PackageNamePrefix    string
+	PackageNameSuffix    string
 	StructName           string
 	UnrollVariadic       bool
 	WithExpecter         bool
@@ -90,6 +92,7 @@ func NewGenerator(ctx context.Context, c GeneratorConfig, iface *Interface, pkg 
 			iface.Pkg.Name(),
 			c.PackageNamePrefix,
 			c.PackageName,
+			c.PackageNameSuffix,
 			c.KeepTree,
 			c.InPackage,
 		)

--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -339,6 +339,7 @@ func (m *Outputter) Generate(ctx context.Context, iface *Interface) error {
 			MockBuildTags:        interfaceConfig.MockBuildTags,
 			PackageName:          interfaceConfig.Outpkg,
 			PackageNamePrefix:    interfaceConfig.Packageprefix,
+			PackageNameSuffix:    interfaceConfig.Packagesuffix,
 			StructName:           interfaceConfig.MockName,
 			UnrollVariadic:       interfaceConfig.UnrollVariadic,
 			WithExpecter:         interfaceConfig.WithExpecter,

--- a/pkg/walker.go
+++ b/pkg/walker.go
@@ -124,6 +124,7 @@ type GeneratorVisitorConfig struct {
 	// The name of the output package, if InPackage is false (defaults to "mocks")
 	PackageName       string
 	PackageNamePrefix string
+	PackageNameSuffix string
 	StructName        string
 	UnrollVariadic    bool
 	WithExpecter      bool
@@ -185,6 +186,7 @@ func (v *GeneratorVisitor) VisitWalk(ctx context.Context, iface *Interface) erro
 		MockBuildTags:        v.config.MockBuildTags,
 		PackageName:          v.config.PackageName,
 		PackageNamePrefix:    v.config.PackageNamePrefix,
+		PackageNameSuffix:    v.config.PackageNameSuffix,
 		StructName:           v.config.StructName,
 		UnrollVariadic:       v.config.UnrollVariadic,
 		WithExpecter:         v.config.WithExpecter,

--- a/pkg/walker_test.go
+++ b/pkg/walker_test.go
@@ -121,6 +121,58 @@ func TestPackagePrefix(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile("package prefix_test_test"), bufferedProvider.String())
 }
 
+func TestPackageSuffix(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping recursive walker test")
+	}
+
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+
+	w := Walker{
+		BaseDir:   wd,
+		Recursive: true,
+		LimitOne:  false,
+		Filter:    regexp.MustCompile(".*AsyncProducer*."),
+	}
+
+	bufferedProvider := NewBufferedProvider()
+	visitor := NewGeneratorVisitor(GeneratorVisitorConfig{
+		InPackage:         false,
+		PackageName:       "mocks",
+		PackageNameSuffix: "_suffix_test",
+	}, bufferedProvider, false)
+
+	w.Walk(context.Background(), visitor)
+	assert.Regexp(t, regexp.MustCompile("package test_suffix_test"), bufferedProvider.String())
+}
+
+func TestPackagePrefixAndSuffix(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping recursive walker test")
+	}
+
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+
+	w := Walker{
+		BaseDir:   wd,
+		Recursive: true,
+		LimitOne:  false,
+		Filter:    regexp.MustCompile(".*AsyncProducer*."),
+	}
+
+	bufferedProvider := NewBufferedProvider()
+	visitor := NewGeneratorVisitor(GeneratorVisitorConfig{
+		InPackage:         false,
+		PackageName:       "mocks",
+		PackageNamePrefix: "prefix_test_",
+		PackageNameSuffix: "_suffix_test",
+	}, bufferedProvider, false)
+
+	w.Walk(context.Background(), visitor)
+	assert.Regexp(t, regexp.MustCompile("package prefix_test_test_suffix_test"), bufferedProvider.String())
+}
 func TestWalkerExclude(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping recursive walker test")


### PR DESCRIPTION
Description
-------------

Add option `packagesuffix` as an alternative to `packageprefix` (can be used together)

Why? I used to create packages like foo and foomock (instead mockfoo or mock_foo) and this option will be helpful.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [ ] 1.20
- [ ] 1.21
- [X] 1.22

How Has This Been Tested?
---------------------------

I add unit tests

Checklist
-----------

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
