### PR TITLE
fix: recursive config failure on windows

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
@@ -661,7 +662,7 @@ func (c *Config) subPackages(
 			return nil, fmt.Errorf("failed to make subroot relative to root: %w", err)
 		}
 		absolutePackageName := packageRootName.Join(relativeFilesystemPath.Parts()...)
-		subPackages = append(subPackages, absolutePackageName.String())
+		subPackages = append(subPackages, filepath.ToSlash(absolutePackageName.String()))
 	}
 
 	return subPackages, nil


### PR DESCRIPTION
Description
-------------

Fix failure with "package not found in config" on Windows due to use of backslash in package name instead of forward slash, resulting in the configuration for the sub package not being found.

Fixes: #727

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Version of Golang used when building/testing:
---------------------------------------------

- [x] 1.22

How Has This Been Tested?
---------------------------

Tested on Windows machine to be able to successfully run mockery when given a recursive configuration, confirming we now don't get a failure.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

A unit test for this is not possible as it depends on the OS specific slash separator in used in library functions.