### PR TITLE
Added InterfaceFile

### DIFF
--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -210,6 +210,7 @@ func parseConfigTemplates(ctx context.Context, c *config.Config, iface *Interfac
 	data := struct {
 		InterfaceDir            string
 		InterfaceDirRelative    string
+		InterfaceFile           string
 		InterfaceName           string
 		InterfaceNameCamel      string
 		InterfaceNameLowerCamel string
@@ -222,6 +223,7 @@ func parseConfigTemplates(ctx context.Context, c *config.Config, iface *Interfac
 	}{
 		InterfaceDir:         filepath.Dir(iface.FileName),
 		InterfaceDirRelative: interfaceDirRelative,
+		InterfaceFile:        iface.FileName,
 		InterfaceName:        iface.Name,
 		// Deprecated: All custom case variables of InterfaceName will be removed in the next major version
 		// Use the template functions instead

--- a/pkg/outputter_test.go
+++ b/pkg/outputter_test.go
@@ -97,7 +97,7 @@ func Test_parseConfigTemplates(t *testing.T) {
 			args: args{
 				c: &config.Config{
 					Dir:      "{{.InterfaceDir}}/{{.PackagePath}}",
-					FileName: "{{.InterfaceName}}_{{.InterfaceNameCamel}}_{{.InterfaceNameSnake}}_{{.InterfaceNameLower}}.go",
+					FileName: "{{.InterfaceName}}_{{.InterfaceNameCamel}}_{{.InterfaceNameSnake}}_{{.InterfaceNameLower}}_{{.InterfaceFile}}",
 					MockName: "{{.InterfaceNameLowerCamel}}",
 					Outpkg:   "{{.PackageName}}",
 				},
@@ -110,7 +110,7 @@ func Test_parseConfigTemplates(t *testing.T) {
 			pkg: mockPkg,
 			want: &config.Config{
 				Dir:      "path/to/github.com/user/project/package",
-				FileName: "FooBar_FooBar_foo_bar_foobar.go",
+				FileName: "FooBar_FooBar_foo_bar_foobar_foobar.go",
 				MockName: "fooBar",
 				Outpkg:   "packageName",
 			},

--- a/pkg/outputter_test.go
+++ b/pkg/outputter_test.go
@@ -97,7 +97,7 @@ func Test_parseConfigTemplates(t *testing.T) {
 			args: args{
 				c: &config.Config{
 					Dir:      "{{.InterfaceDir}}/{{.PackagePath}}",
-					FileName: "{{.InterfaceName}}_{{.InterfaceNameCamel}}_{{.InterfaceNameSnake}}_{{.InterfaceNameLower}}_{{.InterfaceFile}}",
+					FileName: "{{.InterfaceName}}_{{.InterfaceNameCamel}}_{{.InterfaceNameSnake}}_{{.InterfaceNameLower}}_{{base .InterfaceFile}}",
 					MockName: "{{.InterfaceNameLowerCamel}}",
 					Outpkg:   "{{.PackageName}}",
 				},


### PR DESCRIPTION
Description
-------------

Added InterfaceFile to available fields in .mockery.yaml template

I would like to name the mock file similarly to the interface file. Currently there is no way to know the interface file name in the template.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

