### PR TITLE
Fixes #769 : Mock files getting created in disk when dry-run is enabled

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -269,7 +269,7 @@ func (r *RootApp) Run() error {
 			}
 			ifaceLog.Debug().Msg("config specifies to generate this interface")
 
-			outputter := pkg.NewOutputter(&r.Config, boilerplate, true)
+			outputter := pkg.NewOutputter(&r.Config, boilerplate, r.Config.DryRun)
 			if err := outputter.Generate(ifaceCtx, iface); err != nil {
 				return err
 			}

--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -351,6 +351,11 @@ func (m *Outputter) Generate(ctx context.Context, iface *Interface) error {
 			return err
 		}
 
+		// If we're in dry-run mode, don't write the mock to disk
+		if m.dryRun {
+			continue
+		}
+
 		outputPath := pathlib.NewPath(interfaceConfig.Dir).Join(interfaceConfig.FileName)
 		if err := outputPath.Parent().MkdirAll(); err != nil {
 			return stackerr.NewStackErrf(err, "failed to mkdir parents of: %v", outputPath)

--- a/pkg/walker.go
+++ b/pkg/walker.go
@@ -198,12 +198,15 @@ func (v *GeneratorVisitor) VisitWalk(ctx context.Context, iface *Interface) erro
 		return err
 	}
 
-	if !v.dryRun {
-		log.Info().Msgf("writing mock to file")
-		err = gen.Write(out)
-		if err != nil {
-			return err
-		}
+	// If we're in dry-run mode, avoid writing the mock to disk
+	if v.dryRun {
+		return nil
+	}
+
+	log.Info().Msgf("writing mock to file")
+	err = gen.Write(out)
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Description
-------------

Fix mock files and directory getting created in disk when dry-run mode is enabled.

- Fixes #769 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [ ] 1.20
- [ ] 1.21
- [x] 1.22

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

