### PR TITLE
Skip RunAndReturn() on functions with no returns

### DIFF
--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Expecter.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Expecter.go
@@ -149,11 +149,6 @@ func (_c *Expecter_NoReturn_Call) Return() *Expecter_NoReturn_Call {
 	return _c
 }
 
-func (_c *Expecter_NoReturn_Call) RunAndReturn(run func(string)) *Expecter_NoReturn_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Variadic provides a mock function with given fields: ints
 func (_m *Expecter) Variadic(ints ...int) error {
 	_va := make([]interface{}, len(ints))

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/ExpecterAndRolledVariadic.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/ExpecterAndRolledVariadic.go
@@ -149,11 +149,6 @@ func (_c *ExpecterAndRolledVariadic_NoReturn_Call) Return() *ExpecterAndRolledVa
 	return _c
 }
 
-func (_c *ExpecterAndRolledVariadic_NoReturn_Call) RunAndReturn(run func(string)) *ExpecterAndRolledVariadic_NoReturn_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Variadic provides a mock function with given fields: ints
 func (_m *ExpecterAndRolledVariadic) Variadic(ints ...int) error {
 	var tmpRet mock.Arguments

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Fooer.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Fooer.go
@@ -45,11 +45,6 @@ func (_c *Fooer_Bar_Call) Return() *Fooer_Bar_Call {
 	return _c
 }
 
-func (_c *Fooer_Bar_Call) RunAndReturn(run func(func([]int))) *Fooer_Bar_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Baz provides a mock function with given fields: path
 func (_m *Fooer) Baz(path string) func(string) string {
 	ret := _m.Called(path)

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/ImportsSameAsPackage.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/ImportsSameAsPackage.go
@@ -142,11 +142,6 @@ func (_c *ImportsSameAsPackage_C_Call) Return() *ImportsSameAsPackage_C_Call {
 	return _c
 }
 
-func (_c *ImportsSameAsPackage_C_Call) RunAndReturn(run func(fixtures.C)) *ImportsSameAsPackage_C_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // NewImportsSameAsPackage creates a new instance of ImportsSameAsPackage. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewImportsSameAsPackage(t interface {

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/MapToInterface.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/MapToInterface.go
@@ -58,11 +58,6 @@ func (_c *MapToInterface_Foo_Call) Return() *MapToInterface_Foo_Call {
 	return _c
 }
 
-func (_c *MapToInterface_Foo_Call) RunAndReturn(run func(...map[string]interface{})) *MapToInterface_Foo_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // NewMapToInterface creates a new instance of MapToInterface. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMapToInterface(t interface {

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Requester4.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Requester4.go
@@ -44,11 +44,6 @@ func (_c *Requester4_Get_Call) Return() *Requester4_Get_Call {
 	return _c
 }
 
-func (_c *Requester4_Get_Call) RunAndReturn(run func()) *Requester4_Get_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // NewRequester4 creates a new instance of Requester4. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewRequester4(t interface {

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterArgSameAsPkg.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/RequesterArgSameAsPkg.go
@@ -45,11 +45,6 @@ func (_c *RequesterArgSameAsPkg_Get_Call) Return() *RequesterArgSameAsPkg_Get_Ca
 	return _c
 }
 
-func (_c *RequesterArgSameAsPkg_Get_Call) RunAndReturn(run func(string)) *RequesterArgSameAsPkg_Get_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // NewRequesterArgSameAsPkg creates a new instance of RequesterArgSameAsPkg. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewRequesterArgSameAsPkg(t interface {

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Sibling.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/Sibling.go
@@ -44,11 +44,6 @@ func (_c *Sibling_DoSomething_Call) Return() *Sibling_DoSomething_Call {
 	return _c
 }
 
-func (_c *Sibling_DoSomething_Call) RunAndReturn(run func()) *Sibling_DoSomething_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // NewSibling creates a new instance of Sibling. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewSibling(t interface {

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/UnsafeInterface.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/UnsafeInterface.go
@@ -49,11 +49,6 @@ func (_c *UnsafeInterface_Do_Call) Return() *UnsafeInterface_Do_Call {
 	return _c
 }
 
-func (_c *UnsafeInterface_Do_Call) RunAndReturn(run func(*unsafe.Pointer)) *UnsafeInterface_Do_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // NewUnsafeInterface creates a new instance of UnsafeInterface. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewUnsafeInterface(t interface {

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/UsesOtherPkgIface.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/UsesOtherPkgIface.go
@@ -48,11 +48,6 @@ func (_c *UsesOtherPkgIface_DoSomethingElse_Call) Return() *UsesOtherPkgIface_Do
 	return _c
 }
 
-func (_c *UsesOtherPkgIface_DoSomethingElse_Call) RunAndReturn(run func(test.Sibling)) *UsesOtherPkgIface_DoSomethingElse_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // NewUsesOtherPkgIface creates a new instance of UsesOtherPkgIface. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewUsesOtherPkgIface(t interface {

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/VariadicNoReturnInterface.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/VariadicNoReturnInterface.go
@@ -58,11 +58,6 @@ func (_c *VariadicNoReturnInterface_VariadicNoReturn_Call) Return() *VariadicNoR
 	return _c
 }
 
-func (_c *VariadicNoReturnInterface_VariadicNoReturn_Call) RunAndReturn(run func(int, ...interface{})) *VariadicNoReturnInterface_VariadicNoReturn_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // NewVariadicNoReturnInterface creates a new instance of VariadicNoReturnInterface. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewVariadicNoReturnInterface(t interface {

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/buildtag/comment/IfaceWithCustomBuildTagInComment.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/buildtag/comment/IfaceWithCustomBuildTagInComment.go
@@ -46,11 +46,6 @@ func (_c *IfaceWithCustomBuildTagInComment_Custom2_Call) Return() *IfaceWithCust
 	return _c
 }
 
-func (_c *IfaceWithCustomBuildTagInComment_Custom2_Call) RunAndReturn(run func()) *IfaceWithCustomBuildTagInComment_Custom2_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Sprintf provides a mock function with given fields: format, a
 func (_m *IfaceWithCustomBuildTagInComment) Sprintf(format string, a ...interface{}) string {
 	var _ca []interface{}

--- a/mocks/github.com/vektra/mockery/v2/pkg/fixtures/requester_unexported.go
+++ b/mocks/github.com/vektra/mockery/v2/pkg/fixtures/requester_unexported.go
@@ -44,11 +44,6 @@ func (_c *requester_unexported_Get_Call) Return() *requester_unexported_Get_Call
 	return _c
 }
 
-func (_c *requester_unexported_Get_Call) RunAndReturn(run func()) *requester_unexported_Get_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // newRequester_unexported creates a new instance of requester_unexported. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func newRequester_unexported(t interface {

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -964,11 +964,13 @@ func (_c *{{.CallStruct}}{{ .InstantiatedTypeString }}) Return({{range .Returns.
 	_c.Call.Return({{range .Returns.Names}}{{.}},{{end}})
 	return _c
 }
+{{- if (gt (len .Returns.Params) 0)}}
 
 func (_c *{{.CallStruct}}{{ .InstantiatedTypeString }}) RunAndReturn(run func({{range .Params.Types}}{{.}},{{end}})({{range .Returns.Types}}{{.}},{{end}})) *{{.CallStruct}}{{ .InstantiatedTypeString }} {
 	_c.Call.Return(run)
 	return _c
 }
+{{- end}}
 `)
 }
 


### PR DESCRIPTION
Description
-------------

On functions that don't return anything, RunAndReturn() doesn't call the function given. To avoid misleading users, this changes mockery to not generate RunAndReturn() on such functions; it doesn't seem particularly useful anyway because there's no return value to specify.

Return() is preserved even though it isn't needed either, to avoid confusion with mock.Call.

- Fixes #506

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

This is technically a breaking change, but it breaks broken code, so on balance it might be better!

Version of Golang used when building/testing:
---------------------------------------------

- [x] 1.22

How Has This Been Tested?
---------------------------

I’ve updated the test suite to account for the expected change.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes