### PR TITLE
Fixes #769 : Mock files getting created in disk when dry-run is enabled

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -269,7 +269,7 @@ func (r *RootApp) Run() error {
 			}
 			ifaceLog.Debug().Msg("config specifies to generate this interface")
 
-			outputter := pkg.NewOutputter(&r.Config, boilerplate, true)
+			outputter := pkg.NewOutputter(&r.Config, boilerplate, r.Config.DryRun)
 			if err := outputter.Generate(ifaceCtx, iface); err != nil {
 				return err
 			}

--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -354,12 +354,18 @@ func (m *Outputter) Generate(ctx context.Context, iface *Interface) error {
 		}
 
 		outputPath := pathlib.NewPath(interfaceConfig.Dir).Join(interfaceConfig.FileName)
+		fileLog := log.With().Stringer(logging.LogKeyFile, outputPath).Logger()
+		fileLog.Info().Msg("writing to file")
+
+		// If we're in dry-run mode, don't complete make directory and write file operations
+		if m.dryRun {
+			continue
+		}
+
 		if err := outputPath.Parent().MkdirAll(); err != nil {
 			return stackerr.NewStackErrf(err, "failed to mkdir parents of: %v", outputPath)
 		}
 
-		fileLog := log.With().Stringer(logging.LogKeyFile, outputPath).Logger()
-		fileLog.Info().Msg("writing to file")
 		file, err := outputPath.OpenFile(os.O_RDWR | os.O_CREATE | os.O_TRUNC)
 		if err != nil {
 			return stackerr.NewStackErrf(err, "failed to open output file for mock: %v", outputPath)

--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -353,11 +353,11 @@ func (m *Outputter) Generate(ctx context.Context, iface *Interface) error {
 			return err
 		}
 
+		// Log where the file would be written to before checking whether to create the directories and files
 		outputPath := pathlib.NewPath(interfaceConfig.Dir).Join(interfaceConfig.FileName)
 		fileLog := log.With().Stringer(logging.LogKeyFile, outputPath).Logger()
 		fileLog.Info().Msg("writing to file")
 
-		// If we're in dry-run mode, don't complete make directory and write file operations
 		if m.dryRun {
 			continue
 		}

--- a/pkg/outputter_test.go
+++ b/pkg/outputter_test.go
@@ -217,11 +217,17 @@ func TestOutputter_Generate(t *testing.T) {
 		name        string
 		packagePath string
 		fields      fields
-		wantErr     bool
+		dryRun      bool
 	}{
 		{
 			name:        "generate normal",
 			packagePath: "github.com/vektra/mockery/v2/pkg/fixtures/example_project",
+			dryRun:      false,
+		},
+		{
+			name:        "generate normal",
+			packagePath: "github.com/vektra/mockery/v2/pkg/fixtures/example_project",
+			dryRun:      true,
 		},
 	}
 	for _, tt := range tests {
@@ -237,7 +243,7 @@ func TestOutputter_Generate(t *testing.T) {
 			m := &Outputter{
 				boilerplate: tt.fields.boilerplate,
 				config:      tt.fields.config,
-				dryRun:      true,
+				dryRun:      tt.dryRun,
 			}
 			parser := NewParser([]string{})
 
@@ -265,7 +271,7 @@ packages:
 				t.Logf("checking if path exists: %v", mockPath)
 				exists, err := mockPath.Exists()
 				require.NoError(t, err)
-				assert.True(t, exists)
+				assert.Equal(t, !tt.dryRun, exists)
 			}
 		})
 	}


### PR DESCRIPTION
Description
-------------

The PR aims to fix an issue with dry-run option when enabled is still creating the mock files in disk. There's an existing [PR](https://github.com/vektra/mockery/pull/775) to resolve this but I can see it's been inactive since April so I thought to start another PR to resolve the comment. If this isn't okay please let me know, I'm still new to contributing to open source.

- Fixes https://github.com/vektra/mockery/issues/769 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Golang used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [ ] 1.20
- [x] 1.22

How Has This Been Tested?
---------------------------

1. Cleared the mocks by running `task mocks.remove` 
2. Added `dry-run: True` to mockery.yaml
3. Ran `task mocks` which should only log and not create the files

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

