### PR TITLE
feat: add pre-commit hook support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,16 @@
+---
+- id: generate-mocks
+  name: generate mocks
+  description: Generate mocks with mockery
+  language: golang
+  entry: go run .
+  types: [go]
+  pass_filenames: false
+
+- id: generate-mocks-local
+  name: generate mocks with local mockery
+  description: Generate mocks with local mockery
+  language: system
+  entry: mockery
+  types: [go]
+  pass_filenames: false

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,8 +32,45 @@ Generate all the mocks for your project:
 
 Install through [brew](https://brew.sh/)
 
-    brew install mockery
-    brew upgrade mockery
+```shell
+brew install mockery
+```
+
+Upgrade to the latest version
+
+```shell
+brew upgrade mockery
+```
+
+### pre-commit
+
+Add the following lines to your `.pre-commit-config.yaml` file
+
+```yaml
+repos:
+  - repo: https://github.com/vektra/mockery
+    rev: v2 # This is a mutable reference to the latest version
+    hooks:
+      - id: generate-mocks
+```
+
+!!! note
+
+    If the file is missing, you can simply create it with this content
+
+Then install the hook with the following command:
+
+```console
+# This one will report a warning about mutable reference
+$ pre-commit install
+
+# This one will fix the warning
+$ pre-commit autoupdate
+```
+
+It will install everything. And from now, your commit will trigger mock generation.
+
+More information about pre-commit can be found on [pre-commit.com/](https://pre-commit.com/)
 
 
 <script type="text/javascript">


### PR DESCRIPTION
Description
-------------

Add pre-commit.com support in mockery.

- Fixes #791

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [ ] 1.20
- [X] Not relevant

How Has This Been Tested?
---------------------------

Locally, by following the guide I provide in installation.md file

Checklist
-----------

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

