### PR TITLE
Ensure generated imports doesn't start with digit

### DIFF
--- a/pkg/fixtures/12345678/http/http.go
+++ b/pkg/fixtures/12345678/http/http.go
@@ -1,0 +1,3 @@
+package http
+
+type MyStruct struct{}

--- a/pkg/fixtures/same_name_imports.go
+++ b/pkg/fixtures/same_name_imports.go
@@ -3,6 +3,7 @@ package test
 import (
 	"net/http"
 
+	number_dir_http "github.com/vektra/mockery/v2/pkg/fixtures/12345678/http"
 	my_http "github.com/vektra/mockery/v2/pkg/fixtures/http"
 )
 
@@ -10,4 +11,5 @@ import (
 type Example interface {
 	A() http.Flusher
 	B(fixtureshttp string) my_http.MyStruct
+	C(fixtureshttp string) number_dir_http.MyStruct
 }

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -25,7 +25,7 @@ import (
 
 const mockConstructorParamTypeNamePrefix = "mockConstructorTestingT"
 
-var invalidIdentifierChar = regexp.MustCompile("[^[:digit:][:alpha:]_]")
+var invalidIdentifierChar = regexp.MustCompile("^[[:digit:]]|[^[:digit:][:alpha:]_]")
 
 func DetermineOutputPackageName(
 	interfaceFileName string,

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -260,6 +260,7 @@ func (s *GeneratorSuite) TestGeneratorPrologueWithMultipleImportsSameName() {
 
 	expected := `package mocks
 
+import _2345678http "github.com/vektra/mockery/v2/pkg/fixtures/12345678/http"
 import fixtureshttp "github.com/vektra/mockery/v2/pkg/fixtures/http"
 import http "net/http"
 import mock "github.com/stretchr/testify/mock"


### PR DESCRIPTION
Description
-------------

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

- Fixes #805

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [x] tip

How Has This Been Tested?
---------------------------
Updated unit tests.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

