### PR TITLE
Bump Go v1.22 to v1.23 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine as builder
+FROM golang:1.23-alpine as builder
 
 RUN apk --update add --no-cache gcc musl-dev
 


### PR DESCRIPTION
Description
-------------

Running mockery v2.45 on docker will not work with applications using v1.23

![image](https://github.com/user-attachments/assets/5fba9161-fe16-45cf-bd6d-cdad9d8904ed)

- Fixes #813 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.11
- [ ] 1.12
- [ ] 1.13
- [ ] 1.14
- [ ] 1.15
- [ ] 1.16
- [ ] 1.17
- [ ] 1.18
- [ ] 1.19
- [ ] 1.20
- [ ] 1.21
- [ ] 1.22
- [x] 1.23

How Has This Been Tested?
---------------------------

Built and tested on my local machine

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<img width="932" alt="image" src="https://github.com/user-attachments/assets/a159b293-4ee9-42b1-8ae3-4409404ae44f">
