### PR TITLE
docs: update typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ mockery provides the ability to easily generate mocks for Golang interfaces usin
 Documentation
 --------------
 
-Documentation is found at out [GitHub Pages site](https://vektra.github.io/mockery/).
+Documentation is found at our [GitHub Pages site](https://vektra.github.io/mockery/).
 
 Development
 ------------


### PR DESCRIPTION
Description
-------------

The word "**out**" doesn't quite make sense in the following text: "Documentation is found at **out** GitHub Pages site". I suppose it is a typo of the word "**our**", which makes the sentence like so: "Documentation is found at **our** GitHub Pages site".

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- N/A

How Has This Been Tested?
---------------------------

- N/A

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
