### PR TITLE
add git & ssh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23-alpine as builder
 
-RUN apk --update add --no-cache gcc musl-dev
+RUN apk --update add --no-cache gcc musl-dev git
 
 COPY mockery /usr/local/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23-alpine as builder
 
-RUN apk --update add --no-cache gcc musl-dev git
+RUN apk --update add --no-cache gcc musl-dev git openssh
 
 COPY mockery /usr/local/bin
 


### PR DESCRIPTION
Description
-------------
when running mockery using docker, it fail to download private repositories.
after configuring the env variable `GOPRIVATE` and mounting the `~/.netrc` it still fails because of missing `git` 
and when using `ssh` got download the repositories its missing `ssh`


- Fixes # (issue)
- https://github.com/vektra/mockery/issues/619
- https://github.com/vektra/mockery/issues/514

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.20
- [ ] 1.21
- [ ] 1.22
- [X] 1.23

How Has This Been Tested?
---------------------------

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Checklist
-----------

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

