### PR TITLE
Enable gofumpt linter and cleanup formatting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
   # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:
     - errcheck
+    - gofumpt
     - gosimple
     - govet
     - ineffassign

--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -113,7 +113,6 @@ func initConfig(
 	viperObj *viper.Viper,
 	configPath *pathlib.Path,
 ) *viper.Viper {
-
 	if baseSearchPath == nil {
 		currentWorkingDir, err := os.Getwd()
 		if err != nil {

--- a/cmd/mockery_test.go
+++ b/cmd/mockery_test.go
@@ -157,14 +157,13 @@ packages:
     interfaces:
       FooInterface:
 `
-	//config := fmt.Sprintf(configFmt, tmpDir)
 	configPath := pathlib.NewPath(tmpDir).Join("config.yaml")
 	require.NoError(t, configPath.WriteFile([]byte(config)))
 
 	goModPath := pathlib.NewPath(tmpDir).Join("go.mod")
 	err := goModPath.WriteFile([]byte(`
 module github.com/testuser/testpackage
-                                                                                                                                                                                 
+
 go 1.20`))
 	require.NoError(t, err)
 
@@ -172,7 +171,7 @@ go 1.20`))
 	require.NoError(t, interfacePath.Parent().MkdirAll())
 	require.NoError(t, interfacePath.WriteFile([]byte(`
 package foopkg
-																																												
+
 type FooInterface interface {
 		Foo()
 		Bar()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -227,7 +227,6 @@ func (c *Config) getPackageConfigMap(ctx context.Context, packageName string) (m
 	emptyMap := map[string]any{}
 	packageSection[packageName] = emptyMap
 	return emptyMap, nil
-
 }
 
 // GetPackageConfig returns a struct representation of the package's config
@@ -490,7 +489,6 @@ func (c *Config) addSubPkgConfig(ctx context.Context, subPkgPath string, parentP
 		// own `config` section and merge with the parent package
 		// if so.
 		subPkgConfig, err := c.getPackageConfigMap(ctx, subPkgPath)
-
 		if err != nil {
 			log.Err(err).Msg("could not get child package config")
 			return fmt.Errorf("failed to get sub-package config: %w", err)
@@ -505,7 +503,6 @@ func (c *Config) addSubPkgConfig(ctx context.Context, subPkgPath string, parentP
 			if _, keyInSubPkg := subPkgConfigSection[key]; !keyInSubPkg {
 				subPkgConfigSection[key] = val
 			}
-
 		}
 	}
 
@@ -737,7 +734,6 @@ func (c *Config) discoverRecursivePackages(ctx context.Context) error {
 	log.Trace().Msg("done discovering recursive packages")
 
 	return nil
-
 }
 
 func contains[T comparable](slice []T, elem T) bool {
@@ -870,7 +866,6 @@ func (c *Config) mergeInConfig(ctx context.Context) error {
 	}
 
 	return nil
-
 }
 
 func (c *Config) getInterfacesForPackage(ctx context.Context, pkgPath string) ([]string, error) {
@@ -928,5 +923,4 @@ func (c *Config) LogUnsupportedPackagesConfig(ctx context.Context) {
 		Str("url", logging.DocsURL("/configuration/#parameter-descriptions")).
 		Logger()
 	l.Error().Msg("use of unsupported options detected. mockery behavior is undefined.")
-
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1273,7 +1273,6 @@ packages:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			ctx := context.Background()
 			tmpdir := pathlib.NewPath(t.TempDir())
 			cfg := tmpdir.Join("config.yaml")
@@ -1308,7 +1307,6 @@ want
 ------
 %v`, string(cfgAsStr), tt.wantCfgMap)
 			}
-
 		})
 	}
 }

--- a/pkg/fixtures/method_args/same_name_arg_and_type/entity_test.go
+++ b/pkg/fixtures/method_args/same_name_arg_and_type/entity_test.go
@@ -66,5 +66,4 @@ func Test(t *testing.T) {
 
 		mockInterfaceA.AssertExpectations(t)
 	})
-
 }

--- a/pkg/fixtures/panic_err_test.go
+++ b/pkg/fixtures/panic_err_test.go
@@ -26,5 +26,4 @@ func TestPanicOnNoReturnValue(t *testing.T) {
 	}()
 
 	m.DoSomething()
-
 }

--- a/pkg/fixtures/test/expecter_test.go
+++ b/pkg/fixtures/test/expecter_test.go
@@ -178,7 +178,6 @@ func TestExpecter(t *testing.T) {
 		require.Equal(t, 5, runCalled)
 		expMock.AssertExpectations(t)
 	})
-
 }
 
 func intfSlice(slice interface{}) []interface{} {

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -502,7 +502,8 @@ type namer interface {
 func (g *Generator) renderNamedType(ctx context.Context, t interface {
 	Obj() *types.TypeName
 	TypeArgs() *types.TypeList
-}) string {
+},
+) string {
 	name := g.getPackageScopedType(ctx, t.Obj())
 	if t.TypeArgs() == nil || t.TypeArgs().Len() == 0 {
 		return name

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -28,6 +28,7 @@ const (
 
 // SemVer is the version of mockery at build time.
 var SemVer = ""
+
 var ErrPkgNotExist = errors.New("package does not exist")
 
 func GetSemverInfo() string {

--- a/pkg/parse.go
+++ b/pkg/parse.go
@@ -49,6 +49,7 @@ func ParserDisableFuncMocks(disable bool) func(*Parser) {
 		p.disableFuncMocks = disable
 	}
 }
+
 func NewParser(buildTags []string, opts ...func(*Parser)) *Parser {
 	var conf packages.Config
 	conf.Mode = packages.NeedTypes |
@@ -234,7 +235,8 @@ func (p *Parser) packageInterfaces(
 	pkg *types.Package,
 	fileName string,
 	declaredInterfaces []string,
-	ifaces []*Interface) []*Interface {
+	ifaces []*Interface,
+) []*Interface {
 	scope := pkg.Scope()
 	for _, name := range declaredInterfaces {
 		obj := scope.Lookup(name)

--- a/pkg/walker_test.go
+++ b/pkg/walker_test.go
@@ -136,7 +136,8 @@ func TestWalkerExclude(t *testing.T) {
 		Config: config.Config{
 			Exclude: []string{
 				getFixturePath("requester"),
-				getFixturePath("generic.go")},
+				getFixturePath("generic.go"),
+			},
 		},
 		Filter: regexp.MustCompile(".*"),
 	}


### PR DESCRIPTION
Description
-------------

The PR removes unnecessary empty lines and clean-ups code formatting. Additionally, enables `gofumpt` linter to ensure empty lines won't appear in the future.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.22
- [x] 1.23

How Has This Been Tested?
---------------------------

By running tests.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
