### PR TITLE
Remove redundant variable declarations

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -186,7 +186,6 @@ func GetRootAppFromViper(v *viper.Viper) (*RootApp, error) {
 func (r *RootApp) Run() error {
 	var recursive bool
 	var filter *regexp.Regexp
-	var err error
 	var limitOne bool
 
 	if r.Quiet {

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -71,7 +71,6 @@ func (s *GeneratorSuite) checkGenerationWithConfig(
 	// it would require changing Write's signature to accept custom options, specifically to
 	// allow the fragments in preexisting cases. It's assumed that this approximation,
 	// just formatting the source, is sufficient for the needs of the current test styles.
-	var actual []byte
 	actual, fmtErr := format.Source(generator.buf.Bytes())
 	s.Require().NoError(fmtErr)
 
@@ -108,7 +107,6 @@ func (s *GeneratorSuite) checkGenerationRegexWithConfig(
 	// it would require changing Write's signature to accept custom options, specifically to
 	// allow the fragments in preexisting cases. It's assumed that this approximation,
 	// just formatting the source, is sufficient for the needs of the current test styles.
-	var actual []byte
 	actual, fmtErr := format.Source(generator.buf.Bytes())
 	s.Require().NoError(fmtErr)
 
@@ -183,7 +181,6 @@ func (s *GeneratorSuite) TestGeneratorExpecterWithRolledVariadic() {
 	)
 	s.Require().NoError(generator.Generate(s.ctx))
 
-	var actual []byte
 	actual, fmtErr := format.Source(generator.buf.Bytes())
 	s.Require().NoError(fmtErr)
 
@@ -418,7 +415,6 @@ func (s *GeneratorSuite) TestGeneratorVariadicArgsAsOneArg() {
 	)
 	s.Require().NoError(generator.Generate(s.ctx))
 
-	var actual []byte
 	actual, fmtErr := format.Source(generator.buf.Bytes())
 	s.Require().NoError(fmtErr)
 
@@ -619,8 +615,7 @@ func (s *GeneratorSuite) TestGeneratorForStructValueReturn() {
 
 func (s *GeneratorSuite) TestGeneratorForStructWithTag() {
 	// StructTag has back-quote, So can't use raw string literals in this test case.
-	var expected string
-	expected += "*struct {"
+	expected := "*struct {"
 	expected += "FieldC int `json:\"field_c\"`"
 	expected += "FieldD int `json:\"field_d\" xml:\"field_d\"`"
 	expected += "}"


### PR DESCRIPTION
Description
-------------

The PR refactors code by removing redundant `var` declarations.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.22
- [x] 1.23

How Has This Been Tested?
---------------------------

Compile and run unit tests.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
