### PR TITLE
Refactor test asserts

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,8 +21,16 @@ linters:
     - prealloc
     - predeclared
     - reassign
+    - testifylint
 linters-settings:
   staticcheck:
     checks:
     - all
     - '-SA1024'
+  testifylint:
+    disable-all: true
+    enable:
+      - compares
+      - empty
+      - expected-actual
+      - len

--- a/pkg/fixtures/test/expecter_test.go
+++ b/pkg/fixtures/test/expecter_test.go
@@ -117,7 +117,7 @@ func TestExpecter(t *testing.T) {
 		require.NoError(t, expMock.Variadic(1, 2, 3, 4))
 		require.NoError(t, expMock.Variadic(2, 3, 4))
 		require.NoError(t, expMock.Variadic(args...))
-		require.Equal(t, runCalled, 5)
+		require.Equal(t, 5, runCalled)
 		expMock.AssertExpectations(t)
 	})
 
@@ -175,7 +175,7 @@ func TestExpecter(t *testing.T) {
 		}).Return(nil).Once()
 		require.NoError(t, expMock.VariadicMany(defaultInt, defaultString, args...))
 
-		require.Equal(t, runCalled, 5)
+		require.Equal(t, 5, runCalled)
 		expMock.AssertExpectations(t)
 	})
 

--- a/pkg/parse_test.go
+++ b/pkg/parse_test.go
@@ -42,7 +42,7 @@ func TestBuildTagInFilename(t *testing.T) {
 	assert.NoError(t, err) // Expect "redeclared in this block" if tags aren't respected
 
 	nodes := parser.Interfaces()
-	assert.Equal(t, 1, len(nodes))
+	require.Len(t, nodes, 1)
 	assert.Equal(t, "IfaceWithBuildTagInFilename", nodes[0].Name)
 }
 
@@ -64,7 +64,7 @@ func TestBuildTagInComment(t *testing.T) {
 	assert.NoError(t, err) // Expect "redeclared in this block" if tags aren't respected
 
 	nodes := parser.Interfaces()
-	assert.Equal(t, 1, len(nodes))
+	require.Len(t, nodes, 1)
 	assert.Equal(t, "IfaceWithBuildTagInComment", nodes[0].Name)
 }
 
@@ -94,6 +94,5 @@ func TestCustomBuildTag(t *testing.T) {
 func TestParsePackages(t *testing.T) {
 	parser := NewParser([]string{})
 	require.NoError(t, parser.ParsePackages(context.Background(), []string{"github.com/vektra/mockery/v2/pkg/fixtures"}))
-	assert.NotEqual(t, 0, len(parser.files))
-
+	assert.NotEmpty(t, parser.files)
 }

--- a/pkg/walker_test.go
+++ b/pkg/walker_test.go
@@ -63,7 +63,7 @@ func TestWalkerHere(t *testing.T) {
 
 	w.Walk(context.Background(), gv)
 
-	assert.True(t, len(gv.Interfaces) > 10)
+	assert.Greater(t, len(gv.Interfaces), 10)
 	first := gv.Interfaces[0]
 	assert.Equal(t, "A", first.Name)
 	assert.Equal(t, getFixturePath("struct_value.go"), first.FileName)
@@ -88,7 +88,7 @@ func TestWalkerRegexp(t *testing.T) {
 
 	w.Walk(context.Background(), gv)
 
-	assert.True(t, len(gv.Interfaces) >= 1)
+	assert.GreaterOrEqual(t, len(gv.Interfaces), 1)
 	first := gv.Interfaces[0]
 	assert.Equal(t, "AsyncProducer", first.Name)
 	assert.Equal(t, getFixturePath("async.go"), first.FileName)


### PR DESCRIPTION
Description
-------------

The PR refactors tests by simplifying asserts: swap actual-expected parameters, use `assert.Len`, `assert.Greater` etc. Additionally, enables `testifylint` to suggests these in a future.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.22
- [x] 1.23

How Has This Been Tested?
---------------------------

Run unit tests.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
