### PR TITLE
Simplify parseConfigTemplates implementation

### DIFF
--- a/pkg/outputter.go
+++ b/pkg/outputter.go
@@ -180,12 +180,9 @@ func (*FileOutputStreamProvider) underscoreCaseName(caseName string) string {
 func parseConfigTemplates(ctx context.Context, c *config.Config, iface *Interface) error {
 	log := zerolog.Ctx(ctx)
 
-	isExported := ast.IsExported(iface.Name)
-	var mock string
-	if isExported {
+	mock := "mock"
+	if ast.IsExported(iface.Name) {
 		mock = "Mock"
-	} else {
-		mock = "mock"
 	}
 
 	workingDir, err := os.Getwd()
@@ -248,12 +245,10 @@ func parseConfigTemplates(ctx context.Context, c *config.Config, iface *Interfac
 		"outpkg":   &c.Outpkg,
 	}
 
-	numIterations := 0
 	changesMade := true
-	for changesMade {
-		if numIterations >= 20 {
-			msg := "infinite loop in template variables detected"
-			log.Error().Msg(msg)
+	for i := 0; changesMade; i++ {
+		if i >= 20 {
+			log.Error().Msg("infinite loop in template variables detected")
 			for key, val := range templateMap {
 				l := log.With().Str("variable-name", key).Str("variable-value", *val).Logger()
 				l.Error().Msg("config variable value")
@@ -282,7 +277,6 @@ func parseConfigTemplates(ctx context.Context, c *config.Config, iface *Interfac
 				changesMade = true
 			}
 		}
-		numIterations += 1
 	}
 
 	return nil


### PR DESCRIPTION
Description
-------------

The PR refactors unexported function `parseConfigTemplates`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.22
- [x] 1.23

How Has This Been Tested?
---------------------------

Check unit tests.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
