### PR TITLE
Refactor to avoid undersore in var names

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,8 +21,13 @@ linters:
     - prealloc
     - predeclared
     - reassign
+    - revive
     - testifylint
 linters-settings:
+  revive:
+    enable-all-rules: false
+    rules:
+      - name: 'var-naming'
   staticcheck:
     checks:
     - all
@@ -34,3 +39,8 @@ linters-settings:
       - empty
       - expected-actual
       - len
+issues:
+  exclude-rules:
+    - linters:
+        - revive
+      text: "var-naming: don't use an underscore in package name"

--- a/cmd/mockery_test.go
+++ b/cmd/mockery_test.go
@@ -20,28 +20,28 @@ func TestNewRootCmd(t *testing.T) {
 func Test_initConfig(t *testing.T) {
 	tests := []struct {
 		name       string
-		base_path  string
+		basePath   string
 		configPath string
 	}{
 		{
 			name:       "test config at base directory",
-			base_path:  "1/2/3/4",
+			basePath:   "1/2/3/4",
 			configPath: "1/2/3/4/.mockery.yaml",
 		},
 		{
 			name:       "test config at upper directory",
-			base_path:  "1/2/3/4",
+			basePath:   "1/2/3/4",
 			configPath: "1/.mockery.yaml",
 		},
 		{
-			name:      "no config file found",
-			base_path: "1/2/3/4",
+			name:     "no config file found",
+			basePath: "1/2/3/4",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := pathlib.NewPath(t.TempDir())
-			baseDir := tmpDir.Join(strings.Split(tt.base_path, "/")...)
+			baseDir := tmpDir.Join(strings.Split(tt.basePath, "/")...)
 			require.NoError(t, baseDir.MkdirAll())
 
 			configPath := pathlib.NewPath("")
@@ -164,7 +164,7 @@ packages:
 	goModPath := pathlib.NewPath(tmpDir).Join("go.mod")
 	err := goModPath.WriteFile([]byte(`
 module github.com/testuser/testpackage
-                                                                                                                                                                                 
+
 go 1.20`))
 	require.NoError(t, err)
 
@@ -172,7 +172,7 @@ go 1.20`))
 	require.NoError(t, interfacePath.Parent().MkdirAll())
 	require.NoError(t, interfacePath.WriteFile([]byte(`
 package foopkg
-																																												
+
 type FooInterface interface {
 		Foo()
 		Bar()

--- a/pkg/fixtures/requester_unexported.go
+++ b/pkg/fixtures/requester_unexported.go
@@ -1,5 +1,5 @@
 package test
 
-type requester_unexported interface {
+type requesterUnexported interface {
 	Get()
 }

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -226,7 +226,7 @@ func (s *GeneratorSuite) TestGeneratorNoNothing() {
 }
 
 func (s *GeneratorSuite) TestGeneratorUnexported() {
-	s.checkGeneration("requester_unexported.go", "requester_unexported", true, "", "")
+	s.checkGeneration("requester_unexported.go", "requesterUnexported", true, "", "")
 }
 
 func (s *GeneratorSuite) TestGeneratorPrologue() {

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -23,7 +23,8 @@ const (
 	LogKeyPath          = "path"
 	LogKeyQualifiedName = "qualified-name"
 	LogKeyPackageName   = "package-name"
-	_defaultSemVer      = "v0.0.0-dev"
+
+	defaultSemVer = "v0.0.0-dev"
 )
 
 // SemVer is the version of mockery at build time.
@@ -38,7 +39,7 @@ func GetSemverInfo() string {
 	if ok && version.Main.Version != "(devel)" && version.Main.Version != "" {
 		return version.Main.Version
 	}
-	return _defaultSemVer
+	return defaultSemVer
 }
 
 func getMinorSemver(semver string) string {


### PR DESCRIPTION
Description
-------------

The PR renames variables and structs to follow `camelCase` naming convention.

According to the https://go.dev/doc/effective_go#mixed-caps
> Finally, the convention in Go is to use MixedCaps or mixedCaps rather than underscores to write multiword names.

Additionally, enables `revive.var-naming` linter to enforce that in future.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.22
- [x] 1.23

How Has This Been Tested?
---------------------------

Run tests.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
