### PR TITLE
Fix minor typos in parser debug logs

### DIFF
--- a/pkg/parse.go
+++ b/pkg/parse.go
@@ -383,7 +383,7 @@ func (nv *NodeVisitor) Visit(node ast.Node) ast.Visitor {
 		case *ast.InterfaceType, *ast.IndexExpr:
 			nv.add(nv.ctx, n)
 		default:
-			log.Debug().Msg("Found node with unacceptable type for mocking. Rejecting.")
+			log.Debug().Msg("found node with unacceptable type for mocking. Rejecting.")
 		}
 	}
 	return nv

--- a/pkg/parse.go
+++ b/pkg/parse.go
@@ -358,6 +358,7 @@ func (nv *NodeVisitor) DeclaredInterfaces() []string {
 func (nv *NodeVisitor) add(ctx context.Context, n *ast.TypeSpec) {
 	log := zerolog.Ctx(ctx)
 	log.Debug().
+		Str("node-name", n.Name.Name).
 		Str("node-type", fmt.Sprintf("%T", n.Type)).
 		Msg("found node with acceptable type for mocking")
 	nv.declaredInterfaces = append(nv.declaredInterfaces, n.Name.Name)


### PR DESCRIPTION
Description
-------------

This PR contains very minor changes to fix a couple of typos in the parser debug logs I found out when investigating #856.

This is how logs currently look like:
```
acceptable node:
03 Dec 24 11:41 CET DBG found node with acceptable type for mocking dry-run=false node-type=*ast.InterfaceType version=v2.49.1
```
```
unacceptable node:
03 Dec 24 11:41 CET DBG Found node with unacceptable type for mocking. Rejecting. dry-run=false node-name=MockFoo node-type=*ast.StructType version=v2.49.1
```

As can be seen, the log for acceptable nodes is missing the name of the node being processed. At the same time, the log message for unacceptable nodes starts with a capital "F". Every other log message in the application starts with a lowercase letter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.22
- [x] 1.23

How Has This Been Tested?
---------------------------

Compared log lines before and after the change. This is how the log lines used as examples in the description look after the changes:
```
acceptable node:
03 Dec 24 11:41 CET DBG found node with acceptable type for mocking dry-run=false node-name=Foo node-type=*ast.InterfaceType version=v2.49.1
```
```
unacceptable node:
03 Dec 24 11:41 CET DBG found node with unacceptable type for mocking. Rejecting. dry-run=false node-name=MockFoo node-type=*ast.StructType version=v2.49.1
```

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] (N/A) I have commented my code, particularly in hard-to-understand areas
- [ ] (N/A) I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] (N/A) I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
