### PR TITLE
Fix empty build tags adding a tags parameter

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -214,7 +214,10 @@ func (r *RootApp) Run() error {
 	if r.Config.Print {
 		osp = &pkg.StdoutStreamProvider{}
 	}
-	buildTags := strings.Split(r.Config.BuildTags, " ")
+	var buildTags []string
+	if r.Config.BuildTags != "" {
+		buildTags = strings.Split(r.Config.BuildTags, " ")
+	}
 
 	var boilerplate string
 	if r.Config.BoilerplateFile != "" {


### PR DESCRIPTION
Description
-------------

`strings.Split` always returns at least 1 item in the result array, even for the empty string. This makes the `packages.Load` call to always have an empty `-tags` parameter.

- Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.22
- [X] 1.23

How Has This Been Tested?
---------------------------

The debug log output showed the empty `-tags` parameter.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
