### PR TITLE
feat(v3): Warning for nonexistent mocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage.txt
 site/
 .task/
 tools/tools
+*.lua

--- a/.mockery.yml
+++ b/.mockery.yml
@@ -16,14 +16,13 @@ packages:
     interfaces:
       RType:
         configs:
-        - {}
-        - mockname: RTypeReplaced1
-          replace-type:
-            github.com/vektra/mockery/v3/internal/fixtures/example_project/replace_type/rti/rt1:
-              RType1:
-                pkg-path: github.com/vektra/mockery/v3/internal/fixtures/example_project/replace_type/rti/rt2
-                type-name: RType2
-
+          - {}
+          - mockname: RTypeReplaced1
+            replace-type:
+              github.com/vektra/mockery/v3/internal/fixtures/example_project/replace_type/rti/rt1:
+                RType1:
+                  pkg-path: github.com/vektra/mockery/v3/internal/fixtures/example_project/replace_type/rti/rt2
+                  type-name: RType2
   github.com/vektra/mockery/v3/internal/fixtures:
     interfaces:
       RequesterVariadic:
@@ -61,4 +60,6 @@ packages:
       all: True
       dir: internal/fixtures/
       pkgname: test
-
+  github.com/vektra/mockery/v3/internal:
+    interfaces:
+      InterfaceDoesntExist:

--- a/internal/cmd/mockery.go
+++ b/internal/cmd/mockery.go
@@ -358,12 +358,12 @@ func (r *RootApp) Run() error {
 
 	// The loop above could exit early, so sometimes warnings won't be shown
 	// until other errors are fixed
-	for packageName := range missingMap {
-		for iface := range missingMap[packageName] {
+	for packagePath := range missingMap {
+		for ifaceName := range missingMap[packagePath] {
 			log.Warn().
-				Str(logging.LogKeyInterface, iface).
-				Str(logging.LogKeyPackagePath, packageName).
-				Msg("no such interface")
+				Str(logging.LogKeyInterface, ifaceName).
+				Str(logging.LogKeyPackagePath, packagePath).
+				Msg("interface not found in source")
 		}
 	}
 


### PR DESCRIPTION
Description
-------------

Copy of #907 but for v3. Also, no `log.Ctx()` this time :D

- Fixes #905 for v3

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.22
- [x] 1.23

How Has This Been Tested?
---------------------------

```
2025-02-01T19:46:07.124329000+03:00 WRN no such interface interface=InterfaceDoesntExist package-path=github.com/vektra/mockery/v3/internal version=v0.0.0-dev
```

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---

_On a side note, don’t you think that RootApp.Run is a little too big? Having 2 (or 3 now) huge loops with all the core logic feels like a bit too much. Just my two cents as an outside contributor._

_I've also put my code in there, but looks like it could become a mess with more features_