### PR TITLE
Fix profiling

### DIFF
--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -66,6 +66,7 @@ func NewRootCmd() *cobra.Command {
 	pFlags.Bool("testonly", false, "generate a mock in a _test.go file")
 	pFlags.String("case", "", "name the mocked file using casing convention [camel, snake, underscore]")
 	pFlags.String("note", "", "comment to insert into prologue of each generated file")
+	pFlags.String("cpuprofile", "", "write cpu profile to file")
 	pFlags.String("profile", "", "write cpu profile to file")
 	pFlags.Bool("version", false, "prints the installed version of mockery")
 	pFlags.Bool("quiet", false, `suppresses logger output (equivalent to --log-level="")`)
@@ -215,8 +216,12 @@ func (r *RootApp) Run() error {
 		return nil
 	}
 
-	if r.Config.Profile != "" {
-		f, err := os.Create(r.Config.Profile)
+	if r.Config.Profile != "" || r.Config.Cpuprofile != "" {
+		profile := r.Config.Profile
+		if profile == "" {
+			profile = r.Config.Cpuprofile
+		}
+		f, err := os.Create(profile)
 		if err != nil {
 			return stackerr.NewStackErrf(err, "Failed to create profile file")
 		}

--- a/cmd/mockery.go
+++ b/cmd/mockery.go
@@ -67,7 +67,6 @@ func NewRootCmd() *cobra.Command {
 	pFlags.String("case", "", "name the mocked file using casing convention [camel, snake, underscore]")
 	pFlags.String("note", "", "comment to insert into prologue of each generated file")
 	pFlags.String("cpuprofile", "", "write cpu profile to file")
-	pFlags.String("profile", "", "write cpu profile to file")
 	pFlags.Bool("version", false, "prints the installed version of mockery")
 	pFlags.Bool("quiet", false, `suppresses logger output (equivalent to --log-level="")`)
 	pFlags.Bool("keeptree", false, "keep the tree structure of the original interface files into a different repository. Must be used with XX")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	BuildTags                   string                 `mapstructure:"tags"`
 	Case                        string                 `mapstructure:"case"`
 	Config                      string                 `mapstructure:"config"`
+	Cpuprofile                  string                 `mapstructure:"cpuprofile"`
 	Dir                         string                 `mapstructure:"dir"`
 	DisableConfigSearch         bool                   `mapstructure:"disable-config-search"`
 	DisableDeprecationWarnings  bool                   `mapstructure:"disable-deprecation-warnings"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,7 +38,6 @@ type Config struct {
 	BuildTags                   string                 `mapstructure:"tags"`
 	Case                        string                 `mapstructure:"case"`
 	Config                      string                 `mapstructure:"config"`
-	Cpuprofile                  string                 `mapstructure:"cpuprofile"`
 	Dir                         string                 `mapstructure:"dir"`
 	DisableConfigSearch         bool                   `mapstructure:"disable-config-search"`
 	DisableDeprecationWarnings  bool                   `mapstructure:"disable-deprecation-warnings"`


### PR DESCRIPTION
Description
-------------

This PR fixes the `--profile` flag, mainly by moving it above the
```
	if len(configuredPackages) == 0 {
…
	} else {
…
	}
```
block.

Also the `--cpuprofile` flag was not linked to any config field (anymore?).
I think there was possibly a renaming at some point, and it broke it?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.22
- [x] 1.23

How Has This Been Tested?
---------------------------

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
