### PR TITLE
Revert to Go 1.23 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/vektra/mockery/v2
 
-go 1.24
-
-toolchain go1.24.0
+go 1.23
 
 require (
 	github.com/chigopher/pathlib v0.19.1

--- a/go.work
+++ b/go.work
@@ -1,6 +1,4 @@
-go 1.24.0
-
-toolchain go1.24.0
+go 1.23.0
 
 use (
 	.

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/vektra/mockery/tools
 
-go 1.24.0
+go 1.23
 
 require (
 	github.com/go-errors/errors v1.5.1


### PR DESCRIPTION
It was found in #937 that the upgrade to Go 1.24 in go.mod was both unnecessary and also a breaking change. I made a dumb mistake in thinking the toolchain needed to be upgraded to support the generic type alias syntax introduced in Go 1.24, but all that was needed was upgrading `golang.org/x/tools` which is the utility that parses the syntax.

This fixes #937.
