### PR TITLE
Remove redundant typecheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
     - durationcheck
     - copyloopvar
     - gocheckcompilerdirectives


### PR DESCRIPTION
Description
-------------

This PR removes redundant `typecheck` from the `linters.enable` list.

`typecheck` is not a linter, it doesn't perform any analysis. It's just a way to identify, parse, and display compiling errors and some linter errors.

More info:

- https://golangci-lint.run/welcome/faq/#why-do-you-have-typecheck-errors
- https://golangci-lint.run/welcome/faq/#why-is-it-not-possible-to-skipignore-typecheck-errors

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.22
- [ ] 1.23

How Has This Been Tested?
---------------------------

Execute `golangci-lint run` locally.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
