### PR TITLE
Warn against usage inside a gouroutine

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,14 @@ Why use mockery over gomock?
 4. mockery's CLI is more robust, user-friendly, and provides many more options
 5. mockery supports generics (this may no longer be an advantage if/when gomock supports generics)
 
+Warning about goroutine safety
+------------------------------
+
+As mentioned earlier, mockery relies on `testify`, which comes with a limitation:
+calling an unexpected method on a mock object can cause necessary cleanups such
+as channel closing to be skipped. This means that ideally, mock objects should
+only ever be used from the same goroutine that runs the test function.
+
 Who uses mockery?
 ------------------
 


### PR DESCRIPTION
mockery relies on testify APIs that are not safe to use from outside the goroutine that runs the test function.

See https://github.com/stretchr/testify/pull/1710

Description
-------------

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

- Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.22
- [ ] 1.23

How Has This Been Tested?
---------------------------

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
