### PR TITLE
Make YAML parsing strict; fail on unknown parameters

### DIFF
--- a/.mockery_matryer.yml
+++ b/.mockery_matryer.yml
@@ -1,6 +1,7 @@
 template: matryer
 structname: "Moq{{.InterfaceName}}"
 filename: "mocks_matryer_{{.SrcPackageName}}_test.go"
+
 all: true
 template-data:
   skip-ensure: False

--- a/.mockery_testify.yml
+++ b/.mockery_testify.yml
@@ -1,6 +1,5 @@
 template: "testify"
 force-file-write: true
-tags: "custom2"
 formatter: "goimports"
 all: True
 dir: "{{.InterfaceDirRelative}}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,17 +25,14 @@ tasks:
       - rm -rf mocks/
 
   mocks.generate.custom:
-    silent: True
     cmds:
       - go run .
 
   mocks.generate.mockery:
-    silent: True
     cmds:
       - MOCKERY_CONFIG=./.mockery_testify.yml go run .
 
   mocks.generate.matryer:
-    silent: True
     cmds:
       - MOCKERY_CONFIG=./.mockery_matryer.yml go run .
 

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/brunoga/deep"
 	"github.com/chigopher/pathlib"
+	"github.com/go-viper/mapstructure/v2"
 	koanfYAML "github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
@@ -180,7 +181,13 @@ func NewRootConfig(
 		}
 	}
 
-	if err := k.Unmarshal("", &rootConfig); err != nil {
+	// Second argument is nil because of a weird bug: https://github.com/knadh/koanf/issues/307
+	if err := k.UnmarshalWithConf("", nil, koanf.UnmarshalConf{
+		DecoderConfig: &mapstructure.DecoderConfig{
+			ErrorUnused: true,
+			Result:      &rootConfig,
+		},
+	}); err != nil {
 		return nil, k, fmt.Errorf("unmarshalling config: %w", err)
 	}
 	if err := rootConfig.Initialize(ctx); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestNewRootConfig(t *testing.T) {
-
 	tests := []struct {
 		name    string
 		config  string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/chigopher/pathlib"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRootConfig(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		config  string
+		wantErr error
+	}{
+		{
+			name: "unrecognized parameter",
+			config: `
+packages:
+  github.com/foo/bar:
+    config:
+      unknown: param
+`,
+			wantErr: fmt.Errorf("'packages[github.com/foo/bar].config' has invalid keys: unknown"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configFile := pathlib.NewPath(t.TempDir()).Join("config.yaml")
+			require.NoError(t, configFile.WriteFile([]byte(tt.config)))
+
+			flags := pflag.NewFlagSet("test", pflag.ExitOnError)
+			flags.String("config", "", "")
+
+			require.NoError(t, flags.Parse([]string{"--config", configFile.String()}))
+
+			_, _, err := NewRootConfig(context.Background(), flags)
+			if tt.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				var original error
+				cursor := err
+				for cursor != nil {
+					original = cursor
+					cursor = errors.Unwrap(cursor)
+				}
+				assert.Equal(t, tt.wantErr.Error(), original.Error())
+			}
+		})
+	}
+}

--- a/internal/cmd/mockery.go
+++ b/internal/cmd/mockery.go
@@ -92,7 +92,7 @@ func GetRootApp(ctx context.Context, flags *pflag.FlagSet) (*RootApp, error) {
 	r := &RootApp{}
 	config, _, err := config.NewRootConfig(ctx, flags)
 	if err != nil {
-		return nil, stackerr.NewStackErrf(err, "failed to get config")
+		return nil, fmt.Errorf("getting config: %w", err)
 	}
 	r.Config = *config
 	return r, nil


### PR DESCRIPTION
Koanf will now fail with an error if an unrecognized parameter exists in the yaml config:

```
getting config: unmarshalling config: decoding failed due to the following error(s):

'packages[github.com/vektra/mockery/v3/internal/fixtures].config' has invalid keys: unrecognized
```

This fixes #963
