### PR TITLE
v3: Minor docs fix

### DIFF
--- a/docs/template/matryer.md
+++ b/docs/template/matryer.md
@@ -130,5 +130,5 @@ matryer-style mocks are far simpler, and probably more intuitive, than testify-s
 ### Schema
 
 ```json
-{{ read_raw("../internal/mock_matryer.templ.schema.json") }}
+--8<-- "internal/mock_matryer.templ.schema.json"
 ```

--- a/docs/template/testify.md
+++ b/docs/template/testify.md
@@ -186,7 +186,7 @@ This style of mock also has other interesting methods:
 ### Schema
 
 ```json
-{{ read_raw("../internal/mock_testify.templ.schema.json") }}
+--8<-- "internal/mock_testify.templ.schema.json"
 ```
 
 ## Features

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ markdown_extensions:
       auto_title: true
   - pymdownx.inlinehilite
   - pymdownx.magiclink
+  - pymdownx.snippets
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true


### PR DESCRIPTION
The JSON schema was not rendering correctly in the template docs. Instead of using `read_raw`, use the "embedding external files" feature of code blocks as described here: https://squidfunk.github.io/mkdocs-material/reference/code-blocks/?h=external+files#embedding-external-files
