### PR TITLE
v3: Add `*ast.GenDecl` and `*ast.TypeSpec` comments to `template.Interface`

### DIFF
--- a/e2e/test_template_exercise/exercise.templ
+++ b/e2e/test_template_exercise/exercise.templ
@@ -10,12 +10,23 @@ $import.Qualifier: {{ $import.Qualifier }}
 # MOCK: {{ $i }}
 $interface.Name: {{ $interface.Name }}
 $interface.StructName: {{ $interface.StructName }}
-$interface.Doc.Text: {{ $interface.Doc.Text }}
-$interface.Doc.List:
-{{- range $_, $comment := $interface.Doc.List }}
+
+# COMMENTS
+$interface.Comments.GenDeclDoc.Text: {{ $interface.Comments.GenDeclDoc.Text }}
+$interface.Comments.GenDeclDoc.List:
+{{- range $_, $comment := $interface.Comments.GenDeclDoc.List }}
 {{ $comment }}
 {{- end }}
-$interface.Comment.Text: {{ $interface.Comment.Text }}
+$interface.Comments.TypeSpecDoc.Text: {{ $interface.Comments.TypeSpecDoc.Text }}
+$interface.Comments.TypeSpecDoc.List:
+{{- range $_, $comment := $interface.Comments.TypeSpecDoc.List }}
+{{ $comment }}
+{{- end }}
+$interface.Comments.TypeSpecComment.Text: {{ $interface.Comments.TypeSpecComment.Text }}
+$interface.Comments.TypeSpecComment.List:
+{{- range $_, $comment := $interface.Comments.TypeSpecComment.List }}
+{{ $comment }}
+{{- end }}
 
 {{ range $j, $typeparam := .TypeParams }}
 # TYPE PARAM: {{ $j }}

--- a/e2e/test_template_exercise/exercise.templ
+++ b/e2e/test_template_exercise/exercise.templ
@@ -6,10 +6,16 @@ $import.Path: {{ $import.Path }}
 $import.Qualifier: {{ $import.Qualifier }}
 {{ end }}
 
-{{ range $i, $mock := .Interfaces }}
+{{ range $i, $interface := .Interfaces }}
 # MOCK: {{ $i }}
-$mock.Name: {{ $mock.Name }}
-$mock.StructName: {{ $mock.StructName }}
+$interface.Name: {{ $interface.Name }}
+$interface.StructName: {{ $interface.StructName }}
+$interface.Doc.Text: {{ $interface.Doc.Text }}
+$interface.Doc.List:
+{{- range $_, $comment := $interface.Doc.List }}
+{{ $comment }}
+{{- end }}
+$interface.Comment.Text: {{ $interface.Comment.Text }}
 
 {{ range $j, $typeparam := .TypeParams }}
 # TYPE PARAM: {{ $j }}

--- a/e2e/test_template_exercise/exercise_expected.txt
+++ b/e2e/test_template_exercise/exercise_expected.txt
@@ -14,14 +14,22 @@ $import.Qualifier: constraints
 # MOCK: 0
 $interface.Name: Exercise
 $interface.StructName: MockExercise
-$interface.Doc.Text: Exercise is an interface that is used to render a template that exercises
+
+# COMMENTS
+$interface.Comments.GenDeclDoc.Text: GenDecl comments
+
+$interface.Comments.GenDeclDoc.List:
+// GenDecl comments
+$interface.Comments.TypeSpecDoc.Text: Exercise is an interface that is used to render a template that exercises
 all parts of the template data passed to the template.
 
-$interface.Doc.List:
+$interface.Comments.TypeSpecDoc.List:
 // Exercise is an interface that is used to render a template that exercises
 // all parts of the template data passed to the template.
-$interface.Comment.Text: This is a line comment
+$interface.Comments.TypeSpecComment.Text: This is a line comment
 
+$interface.Comments.TypeSpecComment.List:
+// This is a line comment
 
 
 # TYPE PARAM: 0

--- a/e2e/test_template_exercise/exercise_expected.txt
+++ b/e2e/test_template_exercise/exercise_expected.txt
@@ -12,8 +12,16 @@ $import.Qualifier: constraints
 
 
 # MOCK: 0
-$mock.Name: Exercise
-$mock.StructName: MockExercise
+$interface.Name: Exercise
+$interface.StructName: MockExercise
+$interface.Doc.Text: Exercise is an interface that is used to render a template that exercises
+all parts of the template data passed to the template.
+
+$interface.Doc.List:
+// Exercise is an interface that is used to render a template that exercises
+// all parts of the template data passed to the template.
+$interface.Comment.Text: This is a line comment
+
 
 
 # TYPE PARAM: 0

--- a/internal/cmd/mockery.go
+++ b/internal/cmd/mockery.go
@@ -285,6 +285,7 @@ func (r *RootApp) Run() error {
 				internal.NewInterface(
 					iface.Name,
 					iface.TypeSpec,
+					iface.GenDecl,
 					iface.FileName,
 					iface.File,
 					iface.Pkg,

--- a/internal/cmd/mockery.go
+++ b/internal/cmd/mockery.go
@@ -102,7 +102,7 @@ type InterfaceCollection struct {
 	outFilePath *pathlib.Path
 	srcPkg      *packages.Package
 	outPkgName  string
-	interfaces  []*config.Interface
+	interfaces  []*internal.Interface
 	template    string
 }
 
@@ -118,12 +118,12 @@ func NewInterfaceCollection(
 		outFilePath: outFilePath,
 		srcPkg:      srcPkg,
 		outPkgName:  outPkgName,
-		interfaces:  make([]*config.Interface, 0),
+		interfaces:  make([]*internal.Interface, 0),
 		template:    templ,
 	}
 }
 
-func (i *InterfaceCollection) Append(ctx context.Context, iface *config.Interface) error {
+func (i *InterfaceCollection) Append(ctx context.Context, iface *internal.Interface) error {
 	collectionFilepath := i.outFilePath.String()
 	interfaceFilepath := iface.Config.FilePath().String()
 	log := zerolog.Ctx(ctx).With().
@@ -263,7 +263,7 @@ func (r *RootApp) Run() error {
 		}
 		ifaceConfig := pkgConfig.GetInterfaceConfig(ctx, iface.Name)
 		for _, ifaceConfig := range ifaceConfig.Configs {
-			if err := ifaceConfig.ParseTemplates(ifaceCtx, iface, iface.Pkg); err != nil {
+			if err := ifaceConfig.ParseTemplates(ifaceCtx, iface.FileName, iface.Name, iface.Pkg); err != nil {
 				log.Err(err).Msg("Can't parse config templates for interface")
 				return err
 			}
@@ -282,8 +282,9 @@ func (r *RootApp) Run() error {
 			}
 			if err := mockFileToInterfaces[filePath.String()].Append(
 				ctx,
-				config.NewInterface(
+				internal.NewInterface(
 					iface.Name,
+					iface.TypeSpec,
 					iface.FileName,
 					iface.File,
 					iface.Pkg,
@@ -304,7 +305,7 @@ func (r *RootApp) Run() error {
 		if err != nil {
 			return err
 		}
-		if err := packageConfig.Config.ParseTemplates(ctx, nil, interfacesInFile.srcPkg); err != nil {
+		if err := packageConfig.Config.ParseTemplates(ctx, "", "", interfacesInFile.srcPkg); err != nil {
 			return err
 		}
 

--- a/internal/fixtures/template_exercise/exercise.go
+++ b/internal/fixtures/template_exercise/exercise.go
@@ -6,6 +6,11 @@ import (
 	"golang.org/x/exp/constraints"
 )
 
-type Exercise[T any, Ordered constraints.Ordered] interface {
-	Foo(ctx context.Context, typeParam T, ordered Ordered) error
-}
+type (
+	// Exercise is an interface that is used to render a template that exercises
+	// all parts of the template data passed to the template.
+	Exercise[T any, Ordered constraints.Ordered] interface {
+		// Foo is a foo
+		Foo(ctx context.Context, typeParam T, ordered Ordered) error
+	} // This is a line comment
+)

--- a/internal/fixtures/template_exercise/exercise.go
+++ b/internal/fixtures/template_exercise/exercise.go
@@ -6,6 +6,7 @@ import (
 	"golang.org/x/exp/constraints"
 )
 
+// GenDecl comments
 type (
 	// Exercise is an interface that is used to render a template that exercises
 	// all parts of the template data passed to the template.

--- a/internal/interface.go
+++ b/internal/interface.go
@@ -1,0 +1,35 @@
+package internal
+
+import (
+	"go/ast"
+
+	"github.com/vektra/mockery/v3/config"
+	"golang.org/x/tools/go/packages"
+)
+
+type Interface struct {
+	Name     string // Name of the type to be mocked.
+	TypeSpec *ast.TypeSpec
+	FileName string
+	File     *ast.File
+	Pkg      *packages.Package
+	Config   *config.Config
+}
+
+func NewInterface(
+	name string,
+	typeSpec *ast.TypeSpec,
+	filename string,
+	file *ast.File,
+	pkg *packages.Package,
+	config *config.Config,
+) *Interface {
+	return &Interface{
+		Name:     name,
+		TypeSpec: typeSpec,
+		FileName: filename,
+		File:     file,
+		Pkg:      pkg,
+		Config:   config,
+	}
+}

--- a/internal/interface.go
+++ b/internal/interface.go
@@ -10,6 +10,7 @@ import (
 type Interface struct {
 	Name     string // Name of the type to be mocked.
 	TypeSpec *ast.TypeSpec
+	GenDecl  *ast.GenDecl
 	FileName string
 	File     *ast.File
 	Pkg      *packages.Package
@@ -19,6 +20,7 @@ type Interface struct {
 func NewInterface(
 	name string,
 	typeSpec *ast.TypeSpec,
+	genDecl *ast.GenDecl,
 	filename string,
 	file *ast.File,
 	pkg *packages.Package,
@@ -27,6 +29,7 @@ func NewInterface(
 	return &Interface{
 		Name:     name,
 		TypeSpec: typeSpec,
+		GenDecl:  genDecl,
 		FileName: filename,
 		File:     file,
 		Pkg:      pkg,

--- a/internal/node_visitor.go
+++ b/internal/node_visitor.go
@@ -8,19 +8,23 @@ import (
 	"github.com/rs/zerolog"
 )
 
+type declaredInterface struct {
+	typeSpec *ast.TypeSpec
+	genDecl  *ast.GenDecl
+}
 type NodeVisitor struct {
-	declaredInterfaces []string
+	declaredInterfaces []*ast.TypeSpec
 	ctx                context.Context
 }
 
 func NewNodeVisitor(ctx context.Context) *NodeVisitor {
 	return &NodeVisitor{
-		declaredInterfaces: make([]string, 0),
+		declaredInterfaces: make([]*ast.TypeSpec, 0),
 		ctx:                ctx,
 	}
 }
 
-func (nv *NodeVisitor) DeclaredInterfaces() []string {
+func (nv *NodeVisitor) DeclaredInterfaces() []*ast.TypeSpec {
 	return nv.declaredInterfaces
 }
 
@@ -30,7 +34,7 @@ func (nv *NodeVisitor) add(ctx context.Context, n *ast.TypeSpec) {
 		Str("node-name", n.Name.Name).
 		Str("node-type", fmt.Sprintf("%T", n.Type)).
 		Msg("found type declaration that is a possible interface")
-	nv.declaredInterfaces = append(nv.declaredInterfaces, n.Name.Name)
+	nv.declaredInterfaces = append(nv.declaredInterfaces, n)
 }
 
 func (nv *NodeVisitor) Visit(node ast.Node) ast.Visitor {

--- a/internal/parse.go
+++ b/internal/parse.go
@@ -69,9 +69,9 @@ func (p *Parser) ParsePackages(ctx context.Context, packageNames []string) ([]*I
 
 			scope := pkg.Types.Scope()
 			for _, declaredInterface := range nv.declaredInterfaces {
-				ifaceLog := fileLog.With().Str("interface", declaredInterface.Name.Name).Logger()
+				ifaceLog := fileLog.With().Str("interface", declaredInterface.typeSpec.Name.Name).Logger()
 
-				obj := scope.Lookup(declaredInterface.Name.Name)
+				obj := scope.Lookup(declaredInterface.typeSpec.Name.Name)
 
 				typ, ok := obj.Type().(*types.Named)
 				if !ok {
@@ -91,7 +91,8 @@ func (p *Parser) ParsePackages(ctx context.Context, packageNames []string) ([]*I
 				}
 				interfaces = append(interfaces, NewInterface(
 					name,
-					declaredInterface,
+					declaredInterface.typeSpec,
+					declaredInterface.genDecl,
 					file,
 					fileSyntax,
 					pkg,

--- a/internal/parse.go
+++ b/internal/parse.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog"
-	"github.com/vektra/mockery/v3/config"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -38,9 +37,9 @@ func NewParser(buildTags []string) *Parser {
 	return p
 }
 
-func (p *Parser) ParsePackages(ctx context.Context, packageNames []string) ([]*config.Interface, error) {
+func (p *Parser) ParsePackages(ctx context.Context, packageNames []string) ([]*Interface, error) {
 	log := zerolog.Ctx(ctx)
-	interfaces := []*config.Interface{}
+	interfaces := []*Interface{}
 
 	packages, err := packages.Load(&p.conf, packageNames...)
 	if err != nil {
@@ -70,9 +69,9 @@ func (p *Parser) ParsePackages(ctx context.Context, packageNames []string) ([]*c
 
 			scope := pkg.Types.Scope()
 			for _, declaredInterface := range nv.declaredInterfaces {
-				ifaceLog := fileLog.With().Str("interface", declaredInterface).Logger()
+				ifaceLog := fileLog.With().Str("interface", declaredInterface.Name.Name).Logger()
 
-				obj := scope.Lookup(declaredInterface)
+				obj := scope.Lookup(declaredInterface.Name.Name)
 
 				typ, ok := obj.Type().(*types.Named)
 				if !ok {
@@ -90,9 +89,9 @@ func (p *Parser) ParsePackages(ctx context.Context, packageNames []string) ([]*c
 				if typ.Obj().Pkg() == nil {
 					continue
 				}
-
-				interfaces = append(interfaces, config.NewInterface(
+				interfaces = append(interfaces, NewInterface(
 					name,
+					declaredInterface,
 					file,
 					fileSyntax,
 					pkg,

--- a/internal/template_generator.go
+++ b/internal/template_generator.go
@@ -447,8 +447,7 @@ func (g *TemplateGenerator) Generate(
 			tParams,
 			methods,
 			ifaceMock.Config.TemplateData,
-			ifaceMock.TypeSpec.Comment,
-			ifaceMock.TypeSpec.Doc,
+			template.NewComments(ifaceMock.TypeSpec, ifaceMock.GenDecl),
 		))
 	}
 

--- a/internal/template_generator.go
+++ b/internal/template_generator.go
@@ -392,7 +392,7 @@ func validateSchema(ctx context.Context, data template.Data, schema *gojsonschem
 
 func (g *TemplateGenerator) Generate(
 	ctx context.Context,
-	interfaces []*config.Interface,
+	interfaces []*Interface,
 ) ([]byte, error) {
 	log := zerolog.Ctx(ctx)
 	log.UpdateContext(func(c zerolog.Context) zerolog.Context {
@@ -441,13 +441,15 @@ func (g *TemplateGenerator) Generate(
 		if err != nil {
 			return nil, err
 		}
-		mockData = append(mockData, template.Interface{
-			Name:         ifaceMock.Name,
-			StructName:   *ifaceMock.Config.StructName,
-			TypeParams:   tParams,
-			Methods:      methods,
-			TemplateData: ifaceMock.Config.TemplateData,
-		})
+		mockData = append(mockData, template.NewInterface(
+			ifaceMock.Name,
+			*ifaceMock.Config.StructName,
+			tParams,
+			methods,
+			ifaceMock.Config.TemplateData,
+			ifaceMock.TypeSpec.Comment,
+			ifaceMock.TypeSpec.Doc,
+		))
 	}
 
 	data := template.NewData(

--- a/mockery-tools.env
+++ b/mockery-tools.env
@@ -1,1 +1,1 @@
-VERSION=v3.0.2
+VERSION=v3.1.0

--- a/template/comment_group.go
+++ b/template/comment_group.go
@@ -7,7 +7,10 @@ import "go/ast"
 type Comment string
 
 type CommentGroup struct {
+	// List contains each individual line of the comments exactly as they appear
+	// in source, including comment characters.
 	List []Comment
+	// Text contains the text of the comments without comment characters.
 	Text string
 }
 

--- a/template/comment_group.go
+++ b/template/comment_group.go
@@ -1,10 +1,27 @@
 package template
 
+import "go/ast"
+
 // Comment represents a single line of comments exactly as it appears in source.
-// This includes the "//" or "/*" strings.
+// This includes the "//" or "/*" strings if present.
 type Comment string
 
 type CommentGroup struct {
 	List []Comment
 	Text string
+}
+
+func NewCommentGroupFromAST(comments *ast.CommentGroup) CommentGroup {
+	group := CommentGroup{
+		List: []Comment{},
+		Text: "",
+	}
+	if comments == nil {
+		return group
+	}
+	group.Text = comments.Text()
+	for _, line := range comments.List {
+		group.List = append(group.List, Comment(line.Text))
+	}
+	return group
 }

--- a/template/comment_group.go
+++ b/template/comment_group.go
@@ -1,0 +1,10 @@
+package template
+
+// Comment represents a single line of comments exactly as it appears in source.
+// This includes the "//" or "/*" strings.
+type Comment string
+
+type CommentGroup struct {
+	List []Comment
+	Text string
+}

--- a/template/comments.go
+++ b/template/comments.go
@@ -1,0 +1,17 @@
+package template
+
+import "go/ast"
+
+type Comments struct {
+	GenDeclDoc      CommentGroup
+	TypeSpecComment CommentGroup
+	TypeSpecDoc     CommentGroup
+}
+
+func NewComments(typeSpec *ast.TypeSpec, genDecl *ast.GenDecl) Comments {
+	return Comments{
+		GenDeclDoc:      NewCommentGroupFromAST(genDecl.Doc),
+		TypeSpecComment: NewCommentGroupFromAST(typeSpec.Comment),
+		TypeSpecDoc:     NewCommentGroupFromAST(typeSpec.Doc),
+	}
+}

--- a/template/comments.go
+++ b/template/comments.go
@@ -3,9 +3,60 @@ package template
 import "go/ast"
 
 type Comments struct {
-	GenDeclDoc      CommentGroup
+	/*
+		GenDeclDoc represents the doc comments for a general declaration.
+		For example, if you were to define an interface with the following comments:
+
+		// Foo defines Bar
+		type Foo interface {
+			Bar() string
+		}
+
+		then GenDeclDoc will contain the "// Foo defines Bar" comment.
+		Similarly, if you define your interface like:
+
+		// hello world
+		type (
+			// Foo defines Bar
+			Foo interface {
+				Bar() string
+			}
+		)
+
+		then GenDeclDoc will contain the "// hello world" comment.
+	*/
+	GenDeclDoc CommentGroup
+	/*
+		TypeSpecComment contains in-line comments for a type spec.
+		For example:
+
+		type Foo interface {
+			Bar() string
+		} // This is a line comment
+	*/
 	TypeSpecComment CommentGroup
-	TypeSpecDoc     CommentGroup
+
+	/*
+		TypeSpecDoc contains the docs for a type spec.
+		For example:
+
+		type (
+			// Foo defines Bar
+			Foo interface {
+				Bar() string
+			}
+		)
+
+		TypeSpecDoc will _not_ contain the comments defined like this:
+
+		// Foo defines Bar
+		type Foo interface {
+			Bar() string
+		}
+
+		The reason is because the Go AST defines this as a comment on an *ast.GenDecl, not an *ast.TypeSpec.
+	*/
+	TypeSpecDoc CommentGroup
 }
 
 func NewComments(typeSpec *ast.TypeSpec, genDecl *ast.GenDecl) Comments {

--- a/template/interface.go
+++ b/template/interface.go
@@ -1,18 +1,13 @@
 package template
 
 import (
-	"go/ast"
-
 	"github.com/vektra/mockery/v3/template_funcs"
 )
 
 // Interface is the data used to generate a mock for some interface.
 type Interface struct {
-	// Comment contains line comments, if any.
-	Comment CommentGroup
-	// Doc contains the associated documentation, if any.
-	Doc     CommentGroup
-	Methods []Method
+	Comments Comments
+	Methods  []Method
 	// Name is the name of the original interface.
 	Name string
 	// StructName is the chosen name for the struct that will implement the interface.
@@ -27,32 +22,15 @@ func NewInterface(
 	typeParams []TypeParam,
 	methods []Method,
 	templateData TemplateData,
-	comment *ast.CommentGroup,
-	doc *ast.CommentGroup,
+	comments Comments,
 ) Interface {
-	var commentGroup, docGroup CommentGroup
-	if comment != nil {
-		commentGroup.Text = comment.Text()
-		commentGroup.List = []Comment{}
-		for _, comment := range comment.List {
-			commentGroup.List = append(commentGroup.List, Comment(comment.Text))
-		}
-	}
-	if doc != nil {
-		docGroup.Text = doc.Text()
-		docGroup.List = []Comment{}
-		for _, comment := range doc.List {
-			docGroup.List = append(docGroup.List, Comment(comment.Text))
-		}
-	}
 	return Interface{
 		Name:         name,
 		StructName:   structName,
 		TypeParams:   typeParams,
 		Methods:      methods,
 		TemplateData: templateData,
-		Comment:      commentGroup,
-		Doc:          docGroup,
+		Comments:     comments,
 	}
 }
 

--- a/template/interface.go
+++ b/template/interface.go
@@ -1,16 +1,59 @@
 package template
 
-import "github.com/vektra/mockery/v3/template_funcs"
+import (
+	"go/ast"
+
+	"github.com/vektra/mockery/v3/template_funcs"
+)
 
 // Interface is the data used to generate a mock for some interface.
 type Interface struct {
+	// Comment contains line comments, if any.
+	Comment CommentGroup
+	// Doc contains the associated documentation, if any.
+	Doc     CommentGroup
+	Methods []Method
 	// Name is the name of the original interface.
 	Name string
 	// StructName is the chosen name for the struct that will implement the interface.
 	StructName   string
-	TypeParams   []TypeParam
-	Methods      []Method
 	TemplateData TemplateData
+	TypeParams   []TypeParam
+}
+
+func NewInterface(
+	name string,
+	structName string,
+	typeParams []TypeParam,
+	methods []Method,
+	templateData TemplateData,
+	comment *ast.CommentGroup,
+	doc *ast.CommentGroup,
+) Interface {
+	var commentGroup, docGroup CommentGroup
+	if comment != nil {
+		commentGroup.Text = comment.Text()
+		commentGroup.List = []Comment{}
+		for _, comment := range comment.List {
+			commentGroup.List = append(commentGroup.List, Comment(comment.Text))
+		}
+	}
+	if doc != nil {
+		docGroup.Text = doc.Text()
+		docGroup.List = []Comment{}
+		for _, comment := range doc.List {
+			docGroup.List = append(docGroup.List, Comment(comment.Text))
+		}
+	}
+	return Interface{
+		Name:         name,
+		StructName:   structName,
+		TypeParams:   typeParams,
+		Methods:      methods,
+		TemplateData: templateData,
+		Comment:      commentGroup,
+		Doc:          docGroup,
+	}
 }
 
 func (m Interface) TypeConstraintTest() string {


### PR DESCRIPTION
Extends the parser to pass doc and comment `*ast.CommentGroup` types into the template data.

There are two places where doc comments can live for a particular type in the AST. The first is in what's called an `*ast.GenDecl` as below:

## `*ast.GenDecl`

```go
// Foo defines Bar
type Foo interface {
	Bar() string
}
```

This is also the same GenDecl doc comment:

```go
// Foo defines Bar
type (
	Foo interface {
		Bar() string
	}
)
```

Doc comments can also lie within an `*ast.TypeSpec`

## `*ast.TypeSpec`

```go
type (
	// Foo defines Bar
	Foo interface {
		Bar() string
	}
)
```

This is the only way that type spec doc comments can exist. Because the Go AST differentiates between these two situations, and because both are likely to be utilized by Go engineers, we provide access to both of these via the `template.Interface` struct.
