### PR TITLE
Fix `with-expecter` in migrate command

### DIFF
--- a/internal/cmd/migrate.go
+++ b/internal/cmd/migrate.go
@@ -401,11 +401,8 @@ func migrateConfig(
 		}
 		v3.TemplateData["unroll-variadic"] = *v2Config.UnrollVariadic
 	}
-	if v2Config.WithExpecter != nil {
-		if v3.TemplateData == nil {
-			v3.TemplateData = map[string]any{}
-		}
-		v3.TemplateData["with-expecter"] = *v2Config.WithExpecter
+	if v2Config.WithExpecter != nil && *v2Config.WithExpecter == false {
+		tbl.Append("deprecated-parameter", "`with-expecter` was removed in v3 because it is permanently enabled.")
 	}
 }
 

--- a/internal/cmd/migrate_test.go
+++ b/internal/cmd/migrate_test.go
@@ -160,8 +160,6 @@ var expectedV3Conf string = `_anchors:
 structname: '{{.InterfaceName}}'
 pkgname: mocks
 template: testify
-template-data:
-  with-expecter: true
 packages:
   github.com/vektra/mockery/v2/pkg:
     interfaces:
@@ -174,9 +172,7 @@ packages:
       all: true
     interfaces:
       Expecter:
-        config:
-          template-data:
-            with-expecter: true
+        config: {}
         configs:
           - structname: ExpecterAndRolledVariadic
             template-data:
@@ -191,9 +187,7 @@ packages:
       RequesterArgSameAsNamedImport: {}
       RequesterReturnElided: {}
       RequesterVariadic:
-        config:
-          template-data:
-            with-expecter: false
+        config: {}
         configs:
           - structname: RequesterVariadicOneArgument
             template-data:
@@ -205,7 +199,6 @@ packages:
         config:
           template-data:
             unroll-variadic: false
-            with-expecter: true
   github.com/vektra/mockery/v2/pkg/fixtures/auto_generated:
     config:
       all: true


### PR DESCRIPTION
Found in #990.