### PR TITLE
Mention PackageName template variable deprecation

### DIFF
--- a/internal/cmd/migrate.go
+++ b/internal/cmd/migrate.go
@@ -267,6 +267,10 @@ func checkDeprecatedTemplateVariables(
 				name:    "InterfaceNameLower",
 				message: "InterfaceNameLower template variable has been deleted. Use \"{{ .InterfaceName | lower }}\" instead",
 			},
+			{
+				name:    "PackageName",
+				message: "PackageName template variable has been deleted. Use \"{{ .SrcPackageName }}\" instead",
+			},
 		} {
 			if strings.Contains(fieldAsString, deprecatedVariable.name) {
 				tbl.Append("template-variable", deprecatedVariable.message)


### PR DESCRIPTION

Description
-------------

Hi, not sure how useful this is, but this commit adds the `PackageName` template deprecation notice to migrate command.

Refs #989

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.22
- [ ] 1.23

How Has This Been Tested?
---------------------------

Checked the output of `go test ./...`

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
