### PR TITLE
Fix variadic parameter handling in `.EXPECT().Run()`

### DIFF
--- a/internal/fixtures/buildtag/comment/mocks_testify_comment_test.go
+++ b/internal/fixtures/buildtag/comment/mocks_testify_comment_test.go
@@ -74,12 +74,7 @@ func (_e *MockIfaceWithBuildTagInComment_Expecter) Sprintf(format interface{}, a
 
 func (_c *MockIfaceWithBuildTagInComment_Sprintf_Call) Run(run func(format string, a ...interface{})) *MockIfaceWithBuildTagInComment_Sprintf_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]interface{}, len(args)-1)
-		for i, a := range args[1:] {
-			if a != nil {
-				variadicArgs[i] = a.(interface{})
-			}
-		}
+		variadicArgs := args[1].([]interface{})
 		run(args[0].(string), variadicArgs...)
 	})
 	return _c

--- a/internal/fixtures/mocks_testify_test_test.go
+++ b/internal/fixtures/mocks_testify_test_test.go
@@ -965,12 +965,7 @@ func (_e *MockExpecterAndRolledVariadic_Expecter) Variadic(ints ...interface{}) 
 
 func (_c *MockExpecterAndRolledVariadic_Variadic_Call) Run(run func(ints ...int)) *MockExpecterAndRolledVariadic_Variadic_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]int, len(args)-0)
-		for i, a := range args[0:] {
-			if a != nil {
-				variadicArgs[i] = a.(int)
-			}
-		}
+		variadicArgs := args[0].([]int)
 		run(variadicArgs...)
 	})
 	return _c
@@ -1025,12 +1020,7 @@ func (_e *MockExpecterAndRolledVariadic_Expecter) VariadicMany(i interface{}, a 
 
 func (_c *MockExpecterAndRolledVariadic_VariadicMany_Call) Run(run func(i int, a string, intfs ...interface{})) *MockExpecterAndRolledVariadic_VariadicMany_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]interface{}, len(args)-2)
-		for i, a := range args[2:] {
-			if a != nil {
-				variadicArgs[i] = a.(interface{})
-			}
-		}
+		variadicArgs := args[2].([]interface{})
 		run(args[0].(int), args[1].(string), variadicArgs...)
 	})
 	return _c
@@ -1377,12 +1367,7 @@ func (_e *MockVariadicNoReturnInterface_Expecter) VariadicNoReturn(j interface{}
 
 func (_c *MockVariadicNoReturnInterface_VariadicNoReturn_Call) Run(run func(j int, is ...interface{})) *MockVariadicNoReturnInterface_VariadicNoReturn_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]interface{}, len(args)-1)
-		for i, a := range args[1:] {
-			if a != nil {
-				variadicArgs[i] = a.(interface{})
-			}
-		}
+		variadicArgs := args[1].([]interface{})
 		run(args[0].(int), variadicArgs...)
 	})
 	return _c
@@ -2768,12 +2753,7 @@ func (_e *MockMapToInterface_Expecter) Foo(arg1 ...interface{}) *MockMapToInterf
 
 func (_c *MockMapToInterface_Foo_Call) Run(run func(arg1 ...map[string]interface{})) *MockMapToInterface_Foo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]map[string]interface{}, len(args)-0)
-		for i, a := range args[0:] {
-			if a != nil {
-				variadicArgs[i] = a.(map[string]interface{})
-			}
-		}
+		variadicArgs := args[0].([]map[string]interface{})
 		run(variadicArgs...)
 	})
 	return _c
@@ -4221,12 +4201,7 @@ func (_e *MockRequesterVariadicOneArgument_Expecter) Get(values ...interface{}) 
 
 func (_c *MockRequesterVariadicOneArgument_Get_Call) Run(run func(values ...string)) *MockRequesterVariadicOneArgument_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]string, len(args)-0)
-		for i, a := range args[0:] {
-			if a != nil {
-				variadicArgs[i] = a.(string)
-			}
-		}
+		variadicArgs := args[0].([]string)
 		run(variadicArgs...)
 	})
 	return _c
@@ -4280,12 +4255,7 @@ func (_e *MockRequesterVariadicOneArgument_Expecter) MultiWriteToFile(filename i
 
 func (_c *MockRequesterVariadicOneArgument_MultiWriteToFile_Call) Run(run func(filename string, w ...io.Writer)) *MockRequesterVariadicOneArgument_MultiWriteToFile_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]io.Writer, len(args)-1)
-		for i, a := range args[1:] {
-			if a != nil {
-				variadicArgs[i] = a.(io.Writer)
-			}
-		}
+		variadicArgs := args[1].([]io.Writer)
 		run(args[0].(string), variadicArgs...)
 	})
 	return _c
@@ -4338,12 +4308,7 @@ func (_e *MockRequesterVariadicOneArgument_Expecter) OneInterface(a ...interface
 
 func (_c *MockRequesterVariadicOneArgument_OneInterface_Call) Run(run func(a ...interface{})) *MockRequesterVariadicOneArgument_OneInterface_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]interface{}, len(args)-0)
-		for i, a := range args[0:] {
-			if a != nil {
-				variadicArgs[i] = a.(interface{})
-			}
-		}
+		variadicArgs := args[0].([]interface{})
 		run(variadicArgs...)
 	})
 	return _c
@@ -4397,12 +4362,7 @@ func (_e *MockRequesterVariadicOneArgument_Expecter) Sprintf(format interface{},
 
 func (_c *MockRequesterVariadicOneArgument_Sprintf_Call) Run(run func(format string, a ...interface{})) *MockRequesterVariadicOneArgument_Sprintf_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]interface{}, len(args)-1)
-		for i, a := range args[1:] {
-			if a != nil {
-				variadicArgs[i] = a.(interface{})
-			}
-		}
+		variadicArgs := args[1].([]interface{})
 		run(args[0].(string), variadicArgs...)
 	})
 	return _c
@@ -5404,12 +5364,7 @@ func (_e *MockVariadicWithMultipleReturns_Expecter) Foo(one interface{}, two ...
 
 func (_c *MockVariadicWithMultipleReturns_Foo_Call) Run(run func(one string, two ...string)) *MockVariadicWithMultipleReturns_Foo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]string, len(args)-1)
-		for i, a := range args[1:] {
-			if a != nil {
-				variadicArgs[i] = a.(string)
-			}
-		}
+		variadicArgs := args[1].([]string)
 		run(args[0].(string), variadicArgs...)
 	})
 	return _c

--- a/internal/fixtures/variadic_with_multiple_returns_test.go
+++ b/internal/fixtures/variadic_with_multiple_returns_test.go
@@ -38,3 +38,29 @@ func TestUnrollVariadic(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "onetwothree", ret)
 }
+
+func TestUnrollVariadicRun(t *testing.T) {
+	var ran bool
+
+	m := NewMockVariadicWithMultipleReturnsUnrollVariadic(t)
+	m.EXPECT().Foo(mock.Anything, mock.Anything, mock.Anything).Run(
+		func(one string, two ...string) {
+			ran = true
+		},
+	).Return("", nil)
+	m.Foo("", "")
+	assert.True(t, ran)
+}
+
+func TestNoUnrollVariadicRun(t *testing.T) {
+	var ran bool
+
+	m := NewMockVariadicWithMultipleReturns(t)
+	m.EXPECT().Foo(mock.Anything, mock.Anything).Run(
+		func(one string, two ...string) {
+			ran = true
+		},
+	).Return("", nil)
+	m.Foo("", "")
+	assert.True(t, ran)
+}

--- a/internal/fixtures/variadic_with_multiple_returns_test.go
+++ b/internal/fixtures/variadic_with_multiple_returns_test.go
@@ -48,6 +48,7 @@ func TestUnrollVariadicRun(t *testing.T) {
 			ran = true
 		},
 	).Return("", nil)
+	//nolint: errcheck
 	m.Foo("", "")
 	assert.True(t, ran)
 }
@@ -61,6 +62,7 @@ func TestNoUnrollVariadicRun(t *testing.T) {
 			ran = true
 		},
 	).Return("", nil)
+	//nolint: errcheck
 	m.Foo("", "")
 	assert.True(t, ran)
 }

--- a/internal/mock_testify.templ
+++ b/internal/mock_testify.templ
@@ -183,12 +183,16 @@ func (_c *{{ $ExpecterCallNameInstantiated }}) Run(run func({{ $method.ArgList }
 	{{- else}}
 		{{- $variadicParam := index $method.Params (len $method.Params | add -1) }}
 		{{- $nonVariadicParams := slice $method.Params 0 (len $method.Params | add -1 )}}
+		{{- if index $mock.TemplateData "unroll-variadic" }}
 		variadicArgs := make([]{{ $variadicParam.TypeStringVariadicUnderlying }}, len(args) - {{len $nonVariadicParams}})
 		for i, a := range args[{{len $nonVariadicParams}}:] {
 			if a != nil {
 				variadicArgs[i] = a.({{ $variadicParam.TypeStringVariadicUnderlying }})
 			}
 		}
+		{{- else }}
+		variadicArgs := args[{{ len $nonVariadicParams }}].({{ $variadicParam.TypeString }})
+		{{- end }}
 		run(
 		{{- range $i, $param := $method.Params }}
 			{{- if (lt $i (len $nonVariadicParams))}}args[{{$i}}].({{ $param.TypeString }}),


### PR DESCRIPTION
An issue was reported where the `.Run()` method of testify mocks was not handling variadic parameters correctly when `unroll-variadic: False`. It was attempting to grab the variadic parameters one by one by iterating through the argument list, when instead it should have just grabbed the last argument and type asserted it as a slice of the variadic type.

Fixes #1024
