### PR TITLE
Fix unknown `MOCKERY_` env vars causing panics

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -54,3 +54,19 @@ packages:
 		})
 	}
 }
+
+func TestNewRootConfigUnknownEnvVar(t *testing.T) {
+	t.Setenv("MOCKERY_UNKNOWN", "foo")
+	configFile := pathlib.NewPath(t.TempDir()).Join("config.yaml")
+	require.NoError(t, configFile.WriteFile([]byte(`
+packages:
+  github.com/vektra/mockery/v3:
+`)))
+
+	flags := pflag.NewFlagSet("test", pflag.ExitOnError)
+	flags.String("config", "", "")
+
+	require.NoError(t, flags.Parse([]string{"--config", configFile.String()}))
+	_, _, err := NewRootConfig(context.Background(), flags)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Fixes #1015. Mockery would panic if it encountered a `MOCKERY_*` env var that was not expected. The fix is to gather a list of koanf tags and check that the normalized key is an expected parameter key. If not, we disregard the env var and log as such.
