### PR TITLE
Disable `goimports` from messing with imports

### DIFF
--- a/internal/fixtures/mocks_matryer_test_test.go
+++ b/internal/fixtures/mocks_matryer_test_test.go
@@ -15,7 +15,7 @@ import (
 	http1 "github.com/vektra/mockery/v3/internal/fixtures/12345678/http"
 	"github.com/vektra/mockery/v3/internal/fixtures/constraints"
 	http0 "github.com/vektra/mockery/v3/internal/fixtures/http"
-	test "github.com/vektra/mockery/v3/internal/fixtures/redefined_type_b"
+	"github.com/vektra/mockery/v3/internal/fixtures/redefined_type_b"
 )
 
 // Ensure that MoqUsesAny does implement UsesAny.

--- a/internal/fixtures/mocks_testify_test_test.go
+++ b/internal/fixtures/mocks_testify_test_test.go
@@ -15,7 +15,7 @@ import (
 	http1 "github.com/vektra/mockery/v3/internal/fixtures/12345678/http"
 	"github.com/vektra/mockery/v3/internal/fixtures/constraints"
 	http0 "github.com/vektra/mockery/v3/internal/fixtures/http"
-	test "github.com/vektra/mockery/v3/internal/fixtures/redefined_type_b"
+	"github.com/vektra/mockery/v3/internal/fixtures/redefined_type_b"
 )
 
 // NewMockUsesAny creates a new instance of MockUsesAny. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/internal/mock_matryer.templ
+++ b/internal/mock_matryer.templ
@@ -14,7 +14,6 @@ package {{.PkgName}}
 {{- if .Interfaces.ImplementsSomeMethod }}
     {{- $_ := .Registry.AddImport "sync" "sync" }}
 {{- end }}
-{{- $_ := .Registry.AddImport "fmt" "fmt" }}
 
 import (
 {{- range .Imports}}

--- a/internal/template_generator.go
+++ b/internal/template_generator.go
@@ -496,11 +496,12 @@ func (g *TemplateGenerator) Generate(
 }
 
 func goimports(src []byte) ([]byte, error) {
-	formatted, err := imports.Process("filename", src, &imports.Options{
-		TabWidth:  8,
-		TabIndent: true,
-		Comments:  true,
-		Fragment:  true,
+	formatted, err := imports.Process("/", src, &imports.Options{
+		TabWidth:   8,
+		TabIndent:  true,
+		Comments:   true,
+		Fragment:   true,
+		FormatOnly: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("goimports: %s", err)


### PR DESCRIPTION
It might sound odd to not allow `goimports` to add/delete imports, but this was causing problems in #1019. As a matter of principle, we should not be relying on a tool to fix imports for us. If imports are missing or redundant, that is a problem with the template (or mockery) that should be fixed.
