### PR TITLE
Separate release into reusable github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: "release"
+
+on:
+  workflow_dispatch:
+    inputs: &inputs
+      tag:
+        description: "Tag to release"
+        type: string
+        required: true
+
+  workflow_call:
+    inputs: *inputs
+    secrets:
+        DOCKER_USERNAME:
+          required: true
+          type: string
+        DOCKER_PASSWORD:
+          required: true
+          type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ inputs.tag }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 'stable'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: GoReleaser
+        uses: goreleaser/goreleaser-action@v2.7.0
+        with:
+          args: release --clean
+          version: "<2"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.GORELEASER_HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -60,39 +60,7 @@ jobs:
   release:
     needs: tag
     if: needs.tag.outputs.tag_result == 0
-    runs-on: ubuntu-latest
-    env:
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
-
-    steps:
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 'stable'
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v2.7.0
-        with:
-          args: release --clean
-          version: "<2"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.GORELEASER_HOMEBREW_TAP_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ needs.tag.outputs.requested_version }}
-          #GORELEASER_PREVIOUS_TAG: ${{ needs.tag.outputs.previous_version }}
+    uses: ./.github/workflows/release.yml
+    secrets: inherit
+    with:
+      ref: ${{ github.ref_name }}


### PR DESCRIPTION
Release step is failing for unknown reasons. I suspect this has something to do with git modifying the `.png` and `.gif` files incorrectly due to CRLF to LF conversions. I'm breaking out the release job into a separate reusable workflow that we can manually trigger to further aid in debugging. Also, moving `actions/checkout` from v2 to v4, which may coincidentally fix the issue. We'll see.