### PR TITLE
Remove duplicate config initialize

### DIFF
--- a/internal/cmd/mockery.go
+++ b/internal/cmd/mockery.go
@@ -189,10 +189,6 @@ func (r *RootApp) Run() error {
 	log.Info().Str("config-file", r.Config.ConfigFileUsed()).Msgf("Starting mockery")
 	ctx := log.WithContext(context.Background())
 
-	if err := r.Config.Initialize(ctx); err != nil {
-		return err
-	}
-
 	buildTags := strings.Split(*r.Config.BuildTags, " ")
 
 	configuredPackages, err := r.Config.GetPackages(ctx)


### PR DESCRIPTION
Description
-------------

Remove duplicate config initialization. Config is already initialized at `NewRootConfig`: https://github.com/vektra/mockery/blob/5045e9e5038fb06bc76f8dd6661cd0438291feb8/config/config.go#L212

This, caused a big slow down when using `recursive: true`. In a repo with 86 packages, here are the difference:

Before:
```
➜  go git:(mockery-generate) ✗ time /Users/gustavo/go/bin/mockery
2025-08-16T20:23:23.204690000-03:00 INF Starting mockery config-file=/Users/gustavo/workspace/quasar/go/.mockery.yml version=v0.0.0-dev
...
/Users/gustavo/go/bin/mockery  5.05s user 7.09s system 361% cpu 3.356 total
```

After:
```
➜  go git:(mockery-generate) ✗ time /Users/gustavo/go/bin/mockery
2025-08-16T20:24:29.933908000-03:00 INF Starting mockery config-file=/Users/gustavo/workspace/quasar/go/.mockery.yml version=v0.0.0-dev
...
/Users/gustavo/go/bin/mockery  1.09s user 2.37s system 319% cpu 1.083 total
```

This was found during some tests with https://github.com/vektra/mockery/pull/1105, where I'm testing configuring my root package and using recursive to load my whole module. As I load all packages, I can use the comments in the interface to configure mockery instead of managing a config file. 

I've noticed it was quite slow and found that we're loading the same packages multiple times because the first time we run `initialize`, we load the only configured package and recursively search all the other packages. The second time we run `Initialize`, we already have all packages list, and try to do a recursive search on each one of them.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.22
- [ ] 1.23
- [x] 1.24

How Has This Been Tested?
---------------------------

All mocks/tests are still working.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
