### PR TITLE
fix(cmd): fix file descriptor leak from defer in loop

### DIFF
--- a/foo_test.go
+++ b/foo_test.go
@@ -8,6 +8,6 @@ import (
 
 func TestFoo(t *testing.T) {
 	m := newMockfoo(t)
-	m.EXPECT().Bar().Return(baz("foo"))
-	assert.Equal(t, "foo", m.Bar())
+	m.EXPECT().Bar().Return("foo")
+	assert.Equal(t, baz("foo"), m.Bar())
 }

--- a/internal/cmd/mockery.go
+++ b/internal/cmd/mockery.go
@@ -178,6 +178,18 @@ func (i *InterfaceCollection) Append(ctx context.Context, iface *internal.Interf
 	return nil
 }
 
+func writeFile(path string, data []byte) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return stackerr.NewStackErr(err)
+	}
+	defer f.Close()
+	if _, err = f.Write(data); err != nil {
+		return stackerr.NewStackErr(err)
+	}
+	return nil
+}
+
 func (r *RootApp) Run() error {
 	remoteTemplateCache := make(map[string]*internal.RemoteTemplate)
 
@@ -374,13 +386,8 @@ func (r *RootApp) Run() error {
 			return fmt.Errorf("outfile exists")
 		}
 
-		file, err := os.Create(outFilePath)
-		if err != nil {
-			return stackerr.NewStackErr(err)
-		}
-		defer file.Close()
-		if _, err = file.Write(templateBytes); err != nil {
-			return stackerr.NewStackErr(err)
+		if err := writeFile(outFilePath, templateBytes); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Description
-------------

Extract file creation and writing into writeFile() helper so that defer file.Close() runs per-call instead of accumulating until Run() returns. With many mock files, the previous code could exhaust OS file descriptor limits.

- Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [x] 1.25

How Has This Been Tested?
---------------------------

1. go test ./... - no issues
2. e2e/run_all.sh (fails on v3 as well)
> RUNNING /Users/svunion/projects/mockery/e2e/test_missing_interface/run.sh
> task: [mocks.generate.custom] go run .
> 2026-04-02T09:02:44.895693000-07:00 INF Starting mockery config-file=/Users/svunion/projects/mockery/e2e/test_missing_interface/.mockery.yml version=v0.0.0-dev
> 2026-04-02T09:02:44.895769000-07:00 INF Parsing configured packages... version=v0.0.0-dev
> 2026-04-02T09:02:45.008703000-07:00 INF Done parsing configured packages. version=v0.0.0-dev
> 2026-04-02T09:02:45.008739000-07:00 ERR interface not found in source. View the linked documentation for possible reasons why this might occur. docs-url=https://vektra.github.io/mockery/v0.0/faq/#error-interface-not-found-in-source interface=InterfaceDoesntExist package-path=github.com/vektra/mockery/v3/internal version=v0.0.0-dev
> exit status 1
> task: Failed to run task "mocks.generate.custom": exit status 1


Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
