### PR TITLE
fix: replace 'interface{}' (old syntax) with 'any', especially for Te…

### DIFF
--- a/internal/cmd/mocks_testify_cmd_test.go
+++ b/internal/cmd/mocks_testify_cmd_test.go
@@ -70,7 +70,7 @@ type mockargGetter_GetString_Call struct {
 
 // GetString is a helper method to define mock.On call
 //   - name string
-func (_e *mockargGetter_Expecter) GetString(name interface{}) *mockargGetter_GetString_Call {
+func (_e *mockargGetter_Expecter) GetString(name any) *mockargGetter_GetString_Call {
 	return &mockargGetter_GetString_Call{Call: _e.mock.On("GetString", name)}
 }
 

--- a/internal/fixtures/buildtag/comment/mocks_testify_comment_test.go
+++ b/internal/fixtures/buildtag/comment/mocks_testify_comment_test.go
@@ -68,9 +68,9 @@ type MockIfaceWithBuildTagInComment_Sprintf_Call struct {
 // Sprintf is a helper method to define mock.On call
 //   - format string
 //   - a ...interface{}
-func (_e *MockIfaceWithBuildTagInComment_Expecter) Sprintf(format interface{}, a ...interface{}) *MockIfaceWithBuildTagInComment_Sprintf_Call {
+func (_e *MockIfaceWithBuildTagInComment_Expecter) Sprintf(format any, a ...any) *MockIfaceWithBuildTagInComment_Sprintf_Call {
 	return &MockIfaceWithBuildTagInComment_Sprintf_Call{Call: _e.mock.On("Sprintf",
-		append([]interface{}{format}, a...)...)}
+		append([]any{format}, a...)...)}
 }
 
 func (_c *MockIfaceWithBuildTagInComment_Sprintf_Call) Run(run func(format string, a ...interface{})) *MockIfaceWithBuildTagInComment_Sprintf_Call {

--- a/internal/fixtures/directive_comments/mocks_testify_directive_comments_test.go
+++ b/internal/fixtures/directive_comments/mocks_testify_directive_comments_test.go
@@ -72,7 +72,7 @@ type MockRequester_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - path string
-func (_e *MockRequester_Expecter) Get(path interface{}) *MockRequester_Get_Call {
+func (_e *MockRequester_Expecter) Get(path any) *MockRequester_Get_Call {
 	return &MockRequester_Get_Call{Call: _e.mock.On("Get", path)}
 }
 
@@ -140,7 +140,7 @@ type FunServer_HandleRequest_Call struct {
 // HandleRequest is a helper method to define mock.On call
 //   - path string
 //   - handler http.Handler
-func (_e *FunServer_Expecter) HandleRequest(path interface{}, handler interface{}) *FunServer_HandleRequest_Call {
+func (_e *FunServer_Expecter) HandleRequest(path any, handler any) *FunServer_HandleRequest_Call {
 	return &FunServer_HandleRequest_Call{Call: _e.mock.On("HandleRequest", path, handler)}
 }
 

--- a/internal/fixtures/directive_comments/server_with_different_file.go
+++ b/internal/fixtures/directive_comments/server_with_different_file.go
@@ -53,7 +53,7 @@ type FunServerWithDifferentFile_HandleRequest_Call struct {
 // HandleRequest is a helper method to define mock.On call
 //   - path string
 //   - handler http.Handler
-func (_e *FunServerWithDifferentFile_Expecter) HandleRequest(path interface{}, handler interface{}) *FunServerWithDifferentFile_HandleRequest_Call {
+func (_e *FunServerWithDifferentFile_Expecter) HandleRequest(path any, handler any) *FunServerWithDifferentFile_HandleRequest_Call {
 	return &FunServerWithDifferentFile_HandleRequest_Call{Call: _e.mock.On("HandleRequest", path, handler)}
 }
 
@@ -126,7 +126,7 @@ type AnotherFunServerWithDifferentFile_HandleRequest_Call struct {
 // HandleRequest is a helper method to define mock.On call
 //   - path string
 //   - handler http.Handler
-func (_e *AnotherFunServerWithDifferentFile_Expecter) HandleRequest(path interface{}, handler interface{}) *AnotherFunServerWithDifferentFile_HandleRequest_Call {
+func (_e *AnotherFunServerWithDifferentFile_Expecter) HandleRequest(path any, handler any) *AnotherFunServerWithDifferentFile_HandleRequest_Call {
 	return &AnotherFunServerWithDifferentFile_HandleRequest_Call{Call: _e.mock.On("HandleRequest", path, handler)}
 }
 

--- a/internal/fixtures/empty_return/mocks_testify_empty_return_test.go
+++ b/internal/fixtures/empty_return/mocks_testify_empty_return_test.go
@@ -84,7 +84,7 @@ type MockEmptyReturn_WithArgs_Call struct {
 // WithArgs is a helper method to define mock.On call
 //   - a int
 //   - b string
-func (_e *MockEmptyReturn_Expecter) WithArgs(a interface{}, b interface{}) *MockEmptyReturn_WithArgs_Call {
+func (_e *MockEmptyReturn_Expecter) WithArgs(a any, b any) *MockEmptyReturn_WithArgs_Call {
 	return &MockEmptyReturn_WithArgs_Call{Call: _e.mock.On("WithArgs", a, b)}
 }
 

--- a/internal/fixtures/example_project/mocks_testify_example_project_test.go
+++ b/internal/fixtures/example_project/mocks_testify_example_project_test.go
@@ -106,7 +106,7 @@ type MockRoot_TakesBaz_Call struct {
 
 // TakesBaz is a helper method to define mock.On call
 //   - baz *foo.Baz
-func (_e *MockRoot_Expecter) TakesBaz(baz interface{}) *MockRoot_TakesBaz_Call {
+func (_e *MockRoot_Expecter) TakesBaz(baz any) *MockRoot_TakesBaz_Call {
 	return &MockRoot_TakesBaz_Call{Call: _e.mock.On("TakesBaz", baz)}
 }
 

--- a/internal/fixtures/example_project/replace_type/mocks_testify_replace_type_test.go
+++ b/internal/fixtures/example_project/replace_type/mocks_testify_replace_type_test.go
@@ -52,7 +52,7 @@ type MockRType_Replace1_Call struct {
 
 // Replace1 is a helper method to define mock.On call
 //   - f rt1.RType1
-func (_e *MockRType_Expecter) Replace1(f interface{}) *MockRType_Replace1_Call {
+func (_e *MockRType_Expecter) Replace1(f any) *MockRType_Replace1_Call {
 	return &MockRType_Replace1_Call{Call: _e.mock.On("Replace1", f)}
 }
 
@@ -92,7 +92,7 @@ type MockRType_Replace2_Call struct {
 
 // Replace2 is a helper method to define mock.On call
 //   - f rt2.RType2
-func (_e *MockRType_Expecter) Replace2(f interface{}) *MockRType_Replace2_Call {
+func (_e *MockRType_Expecter) Replace2(f any) *MockRType_Replace2_Call {
 	return &MockRType_Replace2_Call{Call: _e.mock.On("Replace2", f)}
 }
 
@@ -159,7 +159,7 @@ type RTypeReplaced1_Replace1_Call struct {
 
 // Replace1 is a helper method to define mock.On call
 //   - f rt2.RType2
-func (_e *RTypeReplaced1_Expecter) Replace1(f interface{}) *RTypeReplaced1_Replace1_Call {
+func (_e *RTypeReplaced1_Expecter) Replace1(f any) *RTypeReplaced1_Replace1_Call {
 	return &RTypeReplaced1_Replace1_Call{Call: _e.mock.On("Replace1", f)}
 }
 
@@ -199,7 +199,7 @@ type RTypeReplaced1_Replace2_Call struct {
 
 // Replace2 is a helper method to define mock.On call
 //   - f rt2.RType2
-func (_e *RTypeReplaced1_Expecter) Replace2(f interface{}) *RTypeReplaced1_Replace2_Call {
+func (_e *RTypeReplaced1_Expecter) Replace2(f any) *RTypeReplaced1_Replace2_Call {
 	return &RTypeReplaced1_Replace2_Call{Call: _e.mock.On("Replace2", f)}
 }
 

--- a/internal/fixtures/iface_typed_param_lowercase/mocks_testify_iface_typed_param_lowercase_test.go
+++ b/internal/fixtures/iface_typed_param_lowercase/mocks_testify_iface_typed_param_lowercase_test.go
@@ -63,7 +63,7 @@ type MockGetterIfaceTypedParam_Get_Call[a comparable] struct {
 
 // Get is a helper method to define mock.On call
 //   - v a
-func (_e *MockGetterIfaceTypedParam_Expecter[a]) Get(v interface{}) *MockGetterIfaceTypedParam_Get_Call[a] {
+func (_e *MockGetterIfaceTypedParam_Expecter[a]) Get(v any) *MockGetterIfaceTypedParam_Get_Call[a] {
 	return &MockGetterIfaceTypedParam_Get_Call[a]{Call: _e.mock.On("Get", v)}
 }
 

--- a/internal/fixtures/index_list_expr/mocks_testify_index_list_expr_test.go
+++ b/internal/fixtures/index_list_expr/mocks_testify_index_list_expr_test.go
@@ -64,7 +64,7 @@ type MockGenericMultipleTypes_Func_Call[T1 any, T2 any, T3 any] struct {
 // Func is a helper method to define mock.On call
 //   - arg1 *T1
 //   - arg2 T2
-func (_e *MockGenericMultipleTypes_Expecter[T1, T2, T3]) Func(arg1 interface{}, arg2 interface{}) *MockGenericMultipleTypes_Func_Call[T1, T2, T3] {
+func (_e *MockGenericMultipleTypes_Expecter[T1, T2, T3]) Func(arg1 any, arg2 any) *MockGenericMultipleTypes_Func_Call[T1, T2, T3] {
 	return &MockGenericMultipleTypes_Func_Call[T1, T2, T3]{Call: _e.mock.On("Func", arg1, arg2)}
 }
 
@@ -148,7 +148,7 @@ type MockIndexListExpr_Func_Call struct {
 // Func is a helper method to define mock.On call
 //   - arg1 *int
 //   - arg2 string
-func (_e *MockIndexListExpr_Expecter) Func(arg1 interface{}, arg2 interface{}) *MockIndexListExpr_Func_Call {
+func (_e *MockIndexListExpr_Expecter) Func(arg1 any, arg2 any) *MockIndexListExpr_Func_Call {
 	return &MockIndexListExpr_Func_Call{Call: _e.mock.On("Func", arg1, arg2)}
 }
 

--- a/internal/fixtures/method_args/same_name_arg_and_type/mocks_testify_same_name_arg_and_type_test.go
+++ b/internal/fixtures/method_args/same_name_arg_and_type/mocks_testify_same_name_arg_and_type_test.go
@@ -63,7 +63,7 @@ type mockinterfaceA_DoB_Call struct {
 
 // DoB is a helper method to define mock.On call
 //   - interfaceB1 interfaceB
-func (_e *mockinterfaceA_Expecter) DoB(interfaceB1 interface{}) *mockinterfaceA_DoB_Call {
+func (_e *mockinterfaceA_Expecter) DoB(interfaceB1 any) *mockinterfaceA_DoB_Call {
 	return &mockinterfaceA_DoB_Call{Call: _e.mock.On("DoB", interfaceB1)}
 }
 
@@ -116,7 +116,7 @@ type mockinterfaceA_DoB0_Call struct {
 
 // DoB0 is a helper method to define mock.On call
 //   - interfaceB interfaceB0
-func (_e *mockinterfaceA_Expecter) DoB0(interfaceB interface{}) *mockinterfaceA_DoB0_Call {
+func (_e *mockinterfaceA_Expecter) DoB0(interfaceB any) *mockinterfaceA_DoB0_Call {
 	return &mockinterfaceA_DoB0_Call{Call: _e.mock.On("DoB0", interfaceB)}
 }
 
@@ -169,7 +169,7 @@ type mockinterfaceA_DoB0v2_Call struct {
 
 // DoB0v2 is a helper method to define mock.On call
 //   - interfaceB01 interfaceB0
-func (_e *mockinterfaceA_Expecter) DoB0v2(interfaceB01 interface{}) *mockinterfaceA_DoB0v2_Call {
+func (_e *mockinterfaceA_Expecter) DoB0v2(interfaceB01 any) *mockinterfaceA_DoB0v2_Call {
 	return &mockinterfaceA_DoB0v2_Call{Call: _e.mock.On("DoB0v2", interfaceB01)}
 }
 
@@ -320,7 +320,7 @@ type mockinterfaceB0_DoB0_Call struct {
 
 // DoB0 is a helper method to define mock.On call
 //   - interfaceB01 interfaceB0
-func (_e *mockinterfaceB0_Expecter) DoB0(interfaceB01 interface{}) *mockinterfaceB0_DoB0_Call {
+func (_e *mockinterfaceB0_Expecter) DoB0(interfaceB01 any) *mockinterfaceB0_DoB0_Call {
 	return &mockinterfaceB0_DoB0_Call{Call: _e.mock.On("DoB0", interfaceB01)}
 }
 

--- a/internal/fixtures/mocks_io_test.go
+++ b/internal/fixtures/mocks_io_test.go
@@ -72,7 +72,7 @@ type MockReader_Read_Call struct {
 
 // Read is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockReader_Expecter) Read(p interface{}) *MockReader_Read_Call {
+func (_e *MockReader_Expecter) Read(p any) *MockReader_Read_Call {
 	return &MockReader_Read_Call{Call: _e.mock.On("Read", p)}
 }
 
@@ -159,7 +159,7 @@ type MockWriter_Write_Call struct {
 
 // Write is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockWriter_Expecter) Write(p interface{}) *MockWriter_Write_Call {
+func (_e *MockWriter_Expecter) Write(p any) *MockWriter_Write_Call {
 	return &MockWriter_Write_Call{Call: _e.mock.On("Write", p)}
 }
 
@@ -318,7 +318,7 @@ type MockSeeker_Seek_Call struct {
 // Seek is a helper method to define mock.On call
 //   - offset int64
 //   - whence int
-func (_e *MockSeeker_Expecter) Seek(offset interface{}, whence interface{}) *MockSeeker_Seek_Call {
+func (_e *MockSeeker_Expecter) Seek(offset any, whence any) *MockSeeker_Seek_Call {
 	return &MockSeeker_Seek_Call{Call: _e.mock.On("Seek", offset, whence)}
 }
 
@@ -410,7 +410,7 @@ type MockReadWriter_Read_Call struct {
 
 // Read is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockReadWriter_Expecter) Read(p interface{}) *MockReadWriter_Read_Call {
+func (_e *MockReadWriter_Expecter) Read(p any) *MockReadWriter_Read_Call {
 	return &MockReadWriter_Read_Call{Call: _e.mock.On("Read", p)}
 }
 
@@ -470,7 +470,7 @@ type MockReadWriter_Write_Call struct {
 
 // Write is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockReadWriter_Expecter) Write(p interface{}) *MockReadWriter_Write_Call {
+func (_e *MockReadWriter_Expecter) Write(p any) *MockReadWriter_Write_Call {
 	return &MockReadWriter_Write_Call{Call: _e.mock.On("Write", p)}
 }
 
@@ -601,7 +601,7 @@ type MockReadCloser_Read_Call struct {
 
 // Read is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockReadCloser_Expecter) Read(p interface{}) *MockReadCloser_Read_Call {
+func (_e *MockReadCloser_Expecter) Read(p any) *MockReadCloser_Read_Call {
 	return &MockReadCloser_Read_Call{Call: _e.mock.On("Read", p)}
 }
 
@@ -732,7 +732,7 @@ type MockWriteCloser_Write_Call struct {
 
 // Write is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockWriteCloser_Expecter) Write(p interface{}) *MockWriteCloser_Write_Call {
+func (_e *MockWriteCloser_Expecter) Write(p any) *MockWriteCloser_Write_Call {
 	return &MockWriteCloser_Write_Call{Call: _e.mock.On("Write", p)}
 }
 
@@ -863,7 +863,7 @@ type MockReadWriteCloser_Read_Call struct {
 
 // Read is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockReadWriteCloser_Expecter) Read(p interface{}) *MockReadWriteCloser_Read_Call {
+func (_e *MockReadWriteCloser_Expecter) Read(p any) *MockReadWriteCloser_Read_Call {
 	return &MockReadWriteCloser_Read_Call{Call: _e.mock.On("Read", p)}
 }
 
@@ -923,7 +923,7 @@ type MockReadWriteCloser_Write_Call struct {
 
 // Write is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockReadWriteCloser_Expecter) Write(p interface{}) *MockReadWriteCloser_Write_Call {
+func (_e *MockReadWriteCloser_Expecter) Write(p any) *MockReadWriteCloser_Write_Call {
 	return &MockReadWriteCloser_Write_Call{Call: _e.mock.On("Write", p)}
 }
 
@@ -1010,7 +1010,7 @@ type MockReadSeeker_Read_Call struct {
 
 // Read is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockReadSeeker_Expecter) Read(p interface{}) *MockReadSeeker_Read_Call {
+func (_e *MockReadSeeker_Expecter) Read(p any) *MockReadSeeker_Read_Call {
 	return &MockReadSeeker_Read_Call{Call: _e.mock.On("Read", p)}
 }
 
@@ -1071,7 +1071,7 @@ type MockReadSeeker_Seek_Call struct {
 // Seek is a helper method to define mock.On call
 //   - offset int64
 //   - whence int
-func (_e *MockReadSeeker_Expecter) Seek(offset interface{}, whence interface{}) *MockReadSeeker_Seek_Call {
+func (_e *MockReadSeeker_Expecter) Seek(offset any, whence any) *MockReadSeeker_Seek_Call {
 	return &MockReadSeeker_Seek_Call{Call: _e.mock.On("Seek", offset, whence)}
 }
 
@@ -1207,7 +1207,7 @@ type MockReadSeekCloser_Read_Call struct {
 
 // Read is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockReadSeekCloser_Expecter) Read(p interface{}) *MockReadSeekCloser_Read_Call {
+func (_e *MockReadSeekCloser_Expecter) Read(p any) *MockReadSeekCloser_Read_Call {
 	return &MockReadSeekCloser_Read_Call{Call: _e.mock.On("Read", p)}
 }
 
@@ -1268,7 +1268,7 @@ type MockReadSeekCloser_Seek_Call struct {
 // Seek is a helper method to define mock.On call
 //   - offset int64
 //   - whence int
-func (_e *MockReadSeekCloser_Expecter) Seek(offset interface{}, whence interface{}) *MockReadSeekCloser_Seek_Call {
+func (_e *MockReadSeekCloser_Expecter) Seek(offset any, whence any) *MockReadSeekCloser_Seek_Call {
 	return &MockReadSeekCloser_Seek_Call{Call: _e.mock.On("Seek", offset, whence)}
 }
 
@@ -1361,7 +1361,7 @@ type MockWriteSeeker_Seek_Call struct {
 // Seek is a helper method to define mock.On call
 //   - offset int64
 //   - whence int
-func (_e *MockWriteSeeker_Expecter) Seek(offset interface{}, whence interface{}) *MockWriteSeeker_Seek_Call {
+func (_e *MockWriteSeeker_Expecter) Seek(offset any, whence any) *MockWriteSeeker_Seek_Call {
 	return &MockWriteSeeker_Seek_Call{Call: _e.mock.On("Seek", offset, whence)}
 }
 
@@ -1426,7 +1426,7 @@ type MockWriteSeeker_Write_Call struct {
 
 // Write is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockWriteSeeker_Expecter) Write(p interface{}) *MockWriteSeeker_Write_Call {
+func (_e *MockWriteSeeker_Expecter) Write(p any) *MockWriteSeeker_Write_Call {
 	return &MockWriteSeeker_Write_Call{Call: _e.mock.On("Write", p)}
 }
 
@@ -1513,7 +1513,7 @@ type MockReadWriteSeeker_Read_Call struct {
 
 // Read is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockReadWriteSeeker_Expecter) Read(p interface{}) *MockReadWriteSeeker_Read_Call {
+func (_e *MockReadWriteSeeker_Expecter) Read(p any) *MockReadWriteSeeker_Read_Call {
 	return &MockReadWriteSeeker_Read_Call{Call: _e.mock.On("Read", p)}
 }
 
@@ -1574,7 +1574,7 @@ type MockReadWriteSeeker_Seek_Call struct {
 // Seek is a helper method to define mock.On call
 //   - offset int64
 //   - whence int
-func (_e *MockReadWriteSeeker_Expecter) Seek(offset interface{}, whence interface{}) *MockReadWriteSeeker_Seek_Call {
+func (_e *MockReadWriteSeeker_Expecter) Seek(offset any, whence any) *MockReadWriteSeeker_Seek_Call {
 	return &MockReadWriteSeeker_Seek_Call{Call: _e.mock.On("Seek", offset, whence)}
 }
 
@@ -1639,7 +1639,7 @@ type MockReadWriteSeeker_Write_Call struct {
 
 // Write is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockReadWriteSeeker_Expecter) Write(p interface{}) *MockReadWriteSeeker_Write_Call {
+func (_e *MockReadWriteSeeker_Expecter) Write(p any) *MockReadWriteSeeker_Write_Call {
 	return &MockReadWriteSeeker_Write_Call{Call: _e.mock.On("Write", p)}
 }
 
@@ -1726,7 +1726,7 @@ type MockReaderFrom_ReadFrom_Call struct {
 
 // ReadFrom is a helper method to define mock.On call
 //   - r io.Reader
-func (_e *MockReaderFrom_Expecter) ReadFrom(r interface{}) *MockReaderFrom_ReadFrom_Call {
+func (_e *MockReaderFrom_Expecter) ReadFrom(r any) *MockReaderFrom_ReadFrom_Call {
 	return &MockReaderFrom_ReadFrom_Call{Call: _e.mock.On("ReadFrom", r)}
 }
 
@@ -1813,7 +1813,7 @@ type MockWriterTo_WriteTo_Call struct {
 
 // WriteTo is a helper method to define mock.On call
 //   - w io.Writer
-func (_e *MockWriterTo_Expecter) WriteTo(w interface{}) *MockWriterTo_WriteTo_Call {
+func (_e *MockWriterTo_Expecter) WriteTo(w any) *MockWriterTo_WriteTo_Call {
 	return &MockWriterTo_WriteTo_Call{Call: _e.mock.On("WriteTo", w)}
 }
 
@@ -1901,7 +1901,7 @@ type MockReaderAt_ReadAt_Call struct {
 // ReadAt is a helper method to define mock.On call
 //   - p []byte
 //   - off int64
-func (_e *MockReaderAt_Expecter) ReadAt(p interface{}, off interface{}) *MockReaderAt_ReadAt_Call {
+func (_e *MockReaderAt_Expecter) ReadAt(p any, off any) *MockReaderAt_ReadAt_Call {
 	return &MockReaderAt_ReadAt_Call{Call: _e.mock.On("ReadAt", p, off)}
 }
 
@@ -1994,7 +1994,7 @@ type MockWriterAt_WriteAt_Call struct {
 // WriteAt is a helper method to define mock.On call
 //   - p []byte
 //   - off int64
-func (_e *MockWriterAt_Expecter) WriteAt(p interface{}, off interface{}) *MockWriterAt_WriteAt_Call {
+func (_e *MockWriterAt_Expecter) WriteAt(p any, off any) *MockWriterAt_WriteAt_Call {
 	return &MockWriterAt_WriteAt_Call{Call: _e.mock.On("WriteAt", p, off)}
 }
 
@@ -2281,7 +2281,7 @@ type MockByteWriter_WriteByte_Call struct {
 
 // WriteByte is a helper method to define mock.On call
 //   - c byte
-func (_e *MockByteWriter_Expecter) WriteByte(c interface{}) *MockByteWriter_WriteByte_Call {
+func (_e *MockByteWriter_Expecter) WriteByte(c any) *MockByteWriter_WriteByte_Call {
 	return &MockByteWriter_WriteByte_Call{Call: _e.mock.On("WriteByte", c)}
 }
 
@@ -2584,7 +2584,7 @@ type MockStringWriter_WriteString_Call struct {
 
 // WriteString is a helper method to define mock.On call
 //   - s string
-func (_e *MockStringWriter_Expecter) WriteString(s interface{}) *MockStringWriter_WriteString_Call {
+func (_e *MockStringWriter_Expecter) WriteString(s any) *MockStringWriter_WriteString_Call {
 	return &MockStringWriter_WriteString_Call{Call: _e.mock.On("WriteString", s)}
 }
 

--- a/internal/fixtures/mocks_net_http_test.go
+++ b/internal/fixtures/mocks_net_http_test.go
@@ -118,7 +118,7 @@ type MockResponseWriter_Write_Call struct {
 
 // Write is a helper method to define mock.On call
 //   - bytes []byte
-func (_e *MockResponseWriter_Expecter) Write(bytes interface{}) *MockResponseWriter_Write_Call {
+func (_e *MockResponseWriter_Expecter) Write(bytes any) *MockResponseWriter_Write_Call {
 	return &MockResponseWriter_Write_Call{Call: _e.mock.On("Write", bytes)}
 }
 
@@ -158,7 +158,7 @@ type MockResponseWriter_WriteHeader_Call struct {
 
 // WriteHeader is a helper method to define mock.On call
 //   - statusCode int
-func (_e *MockResponseWriter_Expecter) WriteHeader(statusCode interface{}) *MockResponseWriter_WriteHeader_Call {
+func (_e *MockResponseWriter_Expecter) WriteHeader(statusCode any) *MockResponseWriter_WriteHeader_Call {
 	return &MockResponseWriter_WriteHeader_Call{Call: _e.mock.On("WriteHeader", statusCode)}
 }
 

--- a/internal/fixtures/mocks_testify_test_test.go
+++ b/internal/fixtures/mocks_testify_test_test.go
@@ -132,7 +132,7 @@ type MockFooer_Bar_Call struct {
 
 // Bar is a helper method to define mock.On call
 //   - f func([]int)
-func (_e *MockFooer_Expecter) Bar(f interface{}) *MockFooer_Bar_Call {
+func (_e *MockFooer_Expecter) Bar(f any) *MockFooer_Bar_Call {
 	return &MockFooer_Bar_Call{Call: _e.mock.On("Bar", f)}
 }
 
@@ -185,7 +185,7 @@ type MockFooer_Baz_Call struct {
 
 // Baz is a helper method to define mock.On call
 //   - path string
-func (_e *MockFooer_Expecter) Baz(path interface{}) *MockFooer_Baz_Call {
+func (_e *MockFooer_Expecter) Baz(path any) *MockFooer_Baz_Call {
 	return &MockFooer_Baz_Call{Call: _e.mock.On("Baz", path)}
 }
 
@@ -236,7 +236,7 @@ type MockFooer_Foo_Call struct {
 
 // Foo is a helper method to define mock.On call
 //   - f func(x string) string
-func (_e *MockFooer_Expecter) Foo(f interface{}) *MockFooer_Foo_Call {
+func (_e *MockFooer_Expecter) Foo(f any) *MockFooer_Foo_Call {
 	return &MockFooer_Foo_Call{Call: _e.mock.On("Foo", f)}
 }
 
@@ -314,7 +314,7 @@ type MockMapFunc_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - m map[string]func(string) string
-func (_e *MockMapFunc_Expecter) Get(m interface{}) *MockMapFunc_Get_Call {
+func (_e *MockMapFunc_Expecter) Get(m any) *MockMapFunc_Get_Call {
 	return &MockMapFunc_Get_Call{Call: _e.mock.On("Get", m)}
 }
 
@@ -568,7 +568,7 @@ type MockConsulLock_Lock_Call struct {
 
 // Lock is a helper method to define mock.On call
 //   - valCh <-chan struct{}
-func (_e *MockConsulLock_Expecter) Lock(valCh interface{}) *MockConsulLock_Lock_Call {
+func (_e *MockConsulLock_Expecter) Lock(valCh any) *MockConsulLock_Lock_Call {
 	return &MockConsulLock_Lock_Call{Call: _e.mock.On("Lock", valCh)}
 }
 
@@ -704,7 +704,7 @@ type MockKeyManager_GetKey_Call struct {
 // GetKey is a helper method to define mock.On call
 //   - s string
 //   - v uint16
-func (_e *MockKeyManager_Expecter) GetKey(s interface{}, v interface{}) *MockKeyManager_GetKey_Call {
+func (_e *MockKeyManager_Expecter) GetKey(s any, v any) *MockKeyManager_GetKey_Call {
 	return &MockKeyManager_GetKey_Call{Call: _e.mock.On("GetKey", s, v)}
 }
 
@@ -787,7 +787,7 @@ type MockBlank_Create_Call struct {
 
 // Create is a helper method to define mock.On call
 //   - x interface{}
-func (_e *MockBlank_Expecter) Create(x interface{}) *MockBlank_Create_Call {
+func (_e *MockBlank_Expecter) Create(x any) *MockBlank_Create_Call {
 	return &MockBlank_Create_Call{Call: _e.mock.On("Create", x)}
 }
 
@@ -877,7 +877,7 @@ type MockExpecterAndRolledVariadic_ManyArgsReturns_Call struct {
 // ManyArgsReturns is a helper method to define mock.On call
 //   - str string
 //   - i int
-func (_e *MockExpecterAndRolledVariadic_Expecter) ManyArgsReturns(str interface{}, i interface{}) *MockExpecterAndRolledVariadic_ManyArgsReturns_Call {
+func (_e *MockExpecterAndRolledVariadic_Expecter) ManyArgsReturns(str any, i any) *MockExpecterAndRolledVariadic_ManyArgsReturns_Call {
 	return &MockExpecterAndRolledVariadic_ManyArgsReturns_Call{Call: _e.mock.On("ManyArgsReturns", str, i)}
 }
 
@@ -966,7 +966,7 @@ type MockExpecterAndRolledVariadic_NoReturn_Call struct {
 
 // NoReturn is a helper method to define mock.On call
 //   - str string
-func (_e *MockExpecterAndRolledVariadic_Expecter) NoReturn(str interface{}) *MockExpecterAndRolledVariadic_NoReturn_Call {
+func (_e *MockExpecterAndRolledVariadic_Expecter) NoReturn(str any) *MockExpecterAndRolledVariadic_NoReturn_Call {
 	return &MockExpecterAndRolledVariadic_NoReturn_Call{Call: _e.mock.On("NoReturn", str)}
 }
 
@@ -1023,9 +1023,9 @@ type MockExpecterAndRolledVariadic_Variadic_Call struct {
 
 // Variadic is a helper method to define mock.On call
 //   - ints ...int
-func (_e *MockExpecterAndRolledVariadic_Expecter) Variadic(ints ...interface{}) *MockExpecterAndRolledVariadic_Variadic_Call {
+func (_e *MockExpecterAndRolledVariadic_Expecter) Variadic(ints ...any) *MockExpecterAndRolledVariadic_Variadic_Call {
 	return &MockExpecterAndRolledVariadic_Variadic_Call{Call: _e.mock.On("Variadic",
-		append([]interface{}{}, ints...)...)}
+		append([]any{}, ints...)...)}
 }
 
 func (_c *MockExpecterAndRolledVariadic_Variadic_Call) Run(run func(ints ...int)) *MockExpecterAndRolledVariadic_Variadic_Call {
@@ -1085,9 +1085,9 @@ type MockExpecterAndRolledVariadic_VariadicMany_Call struct {
 //   - i int
 //   - a string
 //   - intfs ...interface{}
-func (_e *MockExpecterAndRolledVariadic_Expecter) VariadicMany(i interface{}, a interface{}, intfs ...interface{}) *MockExpecterAndRolledVariadic_VariadicMany_Call {
+func (_e *MockExpecterAndRolledVariadic_Expecter) VariadicMany(i any, a any, intfs ...any) *MockExpecterAndRolledVariadic_VariadicMany_Call {
 	return &MockExpecterAndRolledVariadic_VariadicMany_Call{Call: _e.mock.On("VariadicMany",
-		append([]interface{}{i, a}, intfs...)...)}
+		append([]any{i, a}, intfs...)...)}
 }
 
 func (_c *MockExpecterAndRolledVariadic_VariadicMany_Call) Run(run func(i int, a string, intfs ...interface{})) *MockExpecterAndRolledVariadic_VariadicMany_Call {
@@ -1188,7 +1188,7 @@ type MockExpecter_ManyArgsReturns_Call struct {
 // ManyArgsReturns is a helper method to define mock.On call
 //   - str string
 //   - i int
-func (_e *MockExpecter_Expecter) ManyArgsReturns(str interface{}, i interface{}) *MockExpecter_ManyArgsReturns_Call {
+func (_e *MockExpecter_Expecter) ManyArgsReturns(str any, i any) *MockExpecter_ManyArgsReturns_Call {
 	return &MockExpecter_ManyArgsReturns_Call{Call: _e.mock.On("ManyArgsReturns", str, i)}
 }
 
@@ -1277,7 +1277,7 @@ type MockExpecter_NoReturn_Call struct {
 
 // NoReturn is a helper method to define mock.On call
 //   - str string
-func (_e *MockExpecter_Expecter) NoReturn(str interface{}) *MockExpecter_NoReturn_Call {
+func (_e *MockExpecter_Expecter) NoReturn(str any) *MockExpecter_NoReturn_Call {
 	return &MockExpecter_NoReturn_Call{Call: _e.mock.On("NoReturn", str)}
 }
 
@@ -1307,11 +1307,11 @@ func (_c *MockExpecter_NoReturn_Call) RunAndReturn(run func(str string)) *MockEx
 // Variadic provides a mock function for the type MockExpecter
 func (_mock *MockExpecter) Variadic(ints ...int) error {
 	// int
-	_va := make([]interface{}, len(ints))
+	_va := make([]any, len(ints))
 	for _i := range ints {
 		_va[_i] = ints[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, _va...)
 	ret := _mock.Called(_ca...)
 
@@ -1335,9 +1335,9 @@ type MockExpecter_Variadic_Call struct {
 
 // Variadic is a helper method to define mock.On call
 //   - ints ...int
-func (_e *MockExpecter_Expecter) Variadic(ints ...interface{}) *MockExpecter_Variadic_Call {
+func (_e *MockExpecter_Expecter) Variadic(ints ...any) *MockExpecter_Variadic_Call {
 	return &MockExpecter_Variadic_Call{Call: _e.mock.On("Variadic",
-		append([]interface{}{}, ints...)...)}
+		append([]any{}, ints...)...)}
 }
 
 func (_c *MockExpecter_Variadic_Call) Run(run func(ints ...int)) *MockExpecter_Variadic_Call {
@@ -1369,9 +1369,14 @@ func (_c *MockExpecter_Variadic_Call) RunAndReturn(run func(ints ...int) error) 
 
 // VariadicMany provides a mock function for the type MockExpecter
 func (_mock *MockExpecter) VariadicMany(i int, a string, intfs ...interface{}) error {
-	var _ca []interface{}
+	// interface{}
+	_va := make([]any, len(intfs))
+	for _i := range intfs {
+		_va[_i] = intfs[_i]
+	}
+	var _ca []any
 	_ca = append(_ca, i, a)
-	_ca = append(_ca, intfs...)
+	_ca = append(_ca, _va...)
 	ret := _mock.Called(_ca...)
 
 	if len(ret) == 0 {
@@ -1396,9 +1401,9 @@ type MockExpecter_VariadicMany_Call struct {
 //   - i int
 //   - a string
 //   - intfs ...interface{}
-func (_e *MockExpecter_Expecter) VariadicMany(i interface{}, a interface{}, intfs ...interface{}) *MockExpecter_VariadicMany_Call {
+func (_e *MockExpecter_Expecter) VariadicMany(i any, a any, intfs ...any) *MockExpecter_VariadicMany_Call {
 	return &MockExpecter_VariadicMany_Call{Call: _e.mock.On("VariadicMany",
-		append([]interface{}{i, a}, intfs...)...)}
+		append([]any{i, a}, intfs...)...)}
 }
 
 func (_c *MockExpecter_VariadicMany_Call) Run(run func(i int, a string, intfs ...interface{})) *MockExpecter_VariadicMany_Call {
@@ -1484,9 +1489,9 @@ type MockVariadicNoReturnInterface_VariadicNoReturn_Call struct {
 // VariadicNoReturn is a helper method to define mock.On call
 //   - j int
 //   - is ...interface{}
-func (_e *MockVariadicNoReturnInterface_Expecter) VariadicNoReturn(j interface{}, is ...interface{}) *MockVariadicNoReturnInterface_VariadicNoReturn_Call {
+func (_e *MockVariadicNoReturnInterface_Expecter) VariadicNoReturn(j any, is ...any) *MockVariadicNoReturnInterface_VariadicNoReturn_Call {
 	return &MockVariadicNoReturnInterface_VariadicNoReturn_Call{Call: _e.mock.On("VariadicNoReturn",
-		append([]interface{}{j}, is...)...)}
+		append([]any{j}, is...)...)}
 }
 
 func (_c *MockVariadicNoReturnInterface_VariadicNoReturn_Call) Run(run func(j int, is ...interface{})) *MockVariadicNoReturnInterface_VariadicNoReturn_Call {
@@ -1570,7 +1575,7 @@ type MockFuncArgsCollision_Foo_Call struct {
 
 // Foo is a helper method to define mock.On call
 //   - ret interface{}
-func (_e *MockFuncArgsCollision_Expecter) Foo(ret interface{}) *MockFuncArgsCollision_Foo_Call {
+func (_e *MockFuncArgsCollision_Expecter) Foo(ret any) *MockFuncArgsCollision_Foo_Call {
 	return &MockFuncArgsCollision_Foo_Call{Call: _e.mock.On("Foo", ret)}
 }
 
@@ -1668,7 +1673,7 @@ type MockRequesterGenerics_GenericAnonymousStructs_Call[TAny any, TComparable co
 
 // GenericAnonymousStructs is a helper method to define mock.On call
 //   - val struct{Type1 TExternalIntf}
-func (_e *MockRequesterGenerics_Expecter[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]) GenericAnonymousStructs(val interface{}) *MockRequesterGenerics_GenericAnonymousStructs_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
+func (_e *MockRequesterGenerics_Expecter[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]) GenericAnonymousStructs(val any) *MockRequesterGenerics_GenericAnonymousStructs_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
 	return &MockRequesterGenerics_GenericAnonymousStructs_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]{Call: _e.mock.On("GenericAnonymousStructs", val)}
 }
 
@@ -1740,7 +1745,7 @@ type MockRequesterGenerics_GenericArguments_Call[TAny any, TComparable comparabl
 // GenericArguments is a helper method to define mock.On call
 //   - v TAny
 //   - v1 TComparable
-func (_e *MockRequesterGenerics_Expecter[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]) GenericArguments(v interface{}, v1 interface{}) *MockRequesterGenerics_GenericArguments_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
+func (_e *MockRequesterGenerics_Expecter[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]) GenericArguments(v any, v1 any) *MockRequesterGenerics_GenericArguments_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
 	return &MockRequesterGenerics_GenericArguments_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]{Call: _e.mock.On("GenericArguments", v, v1)}
 }
 
@@ -1799,7 +1804,7 @@ type MockRequesterGenerics_GenericStructs_Call[TAny any, TComparable comparable,
 
 // GenericStructs is a helper method to define mock.On call
 //   - genericType GenericType[TAny, TIntf]
-func (_e *MockRequesterGenerics_Expecter[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]) GenericStructs(genericType interface{}) *MockRequesterGenerics_GenericStructs_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
+func (_e *MockRequesterGenerics_Expecter[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]) GenericStructs(genericType any) *MockRequesterGenerics_GenericStructs_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
 	return &MockRequesterGenerics_GenericStructs_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]{Call: _e.mock.On("GenericStructs", genericType)}
 }
 
@@ -2096,7 +2101,7 @@ type MockReplaceGeneric_A_Call[TImport any, TConstraint constraints.Signed, TKee
 
 // A is a helper method to define mock.On call
 //   - t1 TImport
-func (_e *MockReplaceGeneric_Expecter[TImport, TConstraint, TKeep]) A(t1 interface{}) *MockReplaceGeneric_A_Call[TImport, TConstraint, TKeep] {
+func (_e *MockReplaceGeneric_Expecter[TImport, TConstraint, TKeep]) A(t1 any) *MockReplaceGeneric_A_Call[TImport, TConstraint, TKeep] {
 	return &MockReplaceGeneric_A_Call[TImport, TConstraint, TKeep]{Call: _e.mock.On("A", t1)}
 }
 
@@ -2348,7 +2353,7 @@ type MockHasConflictingNestedImports_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - path string
-func (_e *MockHasConflictingNestedImports_Expecter) Get(path interface{}) *MockHasConflictingNestedImports_Get_Call {
+func (_e *MockHasConflictingNestedImports_Expecter) Get(path any) *MockHasConflictingNestedImports_Get_Call {
 	return &MockHasConflictingNestedImports_Get_Call{Call: _e.mock.On("Get", path)}
 }
 
@@ -2549,7 +2554,7 @@ type MockImportsSameAsPackage_C_Call struct {
 
 // C is a helper method to define mock.On call
 //   - c C
-func (_e *MockImportsSameAsPackage_Expecter) C(c interface{}) *MockImportsSameAsPackage_C_Call {
+func (_e *MockImportsSameAsPackage_Expecter) C(c any) *MockImportsSameAsPackage_C_Call {
 	return &MockImportsSameAsPackage_C_Call{Call: _e.mock.On("C", c)}
 }
 
@@ -2627,7 +2632,7 @@ type MockGenericInterface_Func_Call[M any] struct {
 
 // Func is a helper method to define mock.On call
 //   - arg *M
-func (_e *MockGenericInterface_Expecter[M]) Func(arg interface{}) *MockGenericInterface_Func_Call[M] {
+func (_e *MockGenericInterface_Expecter[M]) Func(arg any) *MockGenericInterface_Func_Call[M] {
 	return &MockGenericInterface_Func_Call[M]{Call: _e.mock.On("Func", arg)}
 }
 
@@ -2705,7 +2710,7 @@ type MockInstantiatedGenericInterface_Func_Call struct {
 
 // Func is a helper method to define mock.On call
 //   - arg *float32
-func (_e *MockInstantiatedGenericInterface_Expecter) Func(arg interface{}) *MockInstantiatedGenericInterface_Func_Call {
+func (_e *MockInstantiatedGenericInterface_Expecter) Func(arg any) *MockInstantiatedGenericInterface_Func_Call {
 	return &MockInstantiatedGenericInterface_Func_Call{Call: _e.mock.On("Func", arg)}
 }
 
@@ -2792,7 +2797,7 @@ type MockMyReader_Read_Call struct {
 
 // Read is a helper method to define mock.On call
 //   - p []byte
-func (_e *MockMyReader_Expecter) Read(p interface{}) *MockMyReader_Read_Call {
+func (_e *MockMyReader_Expecter) Read(p any) *MockMyReader_Read_Call {
 	return &MockMyReader_Read_Call{Call: _e.mock.On("Read", p)}
 }
 
@@ -2881,7 +2886,7 @@ type MockIssue766_FetchData_Call struct {
 
 // FetchData is a helper method to define mock.On call
 //   - fetchFunc func(x ...int) ([]int, error)
-func (_e *MockIssue766_Expecter) FetchData(fetchFunc interface{}) *MockIssue766_FetchData_Call {
+func (_e *MockIssue766_Expecter) FetchData(fetchFunc any) *MockIssue766_FetchData_Call {
 	return &MockIssue766_FetchData_Call{Call: _e.mock.On("FetchData", fetchFunc)}
 }
 
@@ -2953,9 +2958,9 @@ type MockMapToInterface_Foo_Call struct {
 
 // Foo is a helper method to define mock.On call
 //   - arg1 ...map[string]interface{}
-func (_e *MockMapToInterface_Expecter) Foo(arg1 ...interface{}) *MockMapToInterface_Foo_Call {
+func (_e *MockMapToInterface_Expecter) Foo(arg1 ...any) *MockMapToInterface_Foo_Call {
 	return &MockMapToInterface_Foo_Call{Call: _e.mock.On("Foo",
-		append([]interface{}{}, arg1...)...)}
+		append([]any{}, arg1...)...)}
 }
 
 func (_c *MockMapToInterface_Foo_Call) Run(run func(arg1 ...map[string]interface{})) *MockMapToInterface_Foo_Call {
@@ -3083,7 +3088,7 @@ type MockUsesOtherPkgIface_DoSomethingElse_Call struct {
 
 // DoSomethingElse is a helper method to define mock.On call
 //   - obj Sibling
-func (_e *MockUsesOtherPkgIface_Expecter) DoSomethingElse(obj interface{}) *MockUsesOtherPkgIface_DoSomethingElse_Call {
+func (_e *MockUsesOtherPkgIface_Expecter) DoSomethingElse(obj any) *MockUsesOtherPkgIface_DoSomethingElse_Call {
 	return &MockUsesOtherPkgIface_DoSomethingElse_Call{Call: _e.mock.On("DoSomethingElse", obj)}
 }
 
@@ -3150,7 +3155,7 @@ type MockNilRun_Foo_Call struct {
 
 // Foo is a helper method to define mock.On call
 //   - nilRun NilRun
-func (_e *MockNilRun_Expecter) Foo(nilRun interface{}) *MockNilRun_Foo_Call {
+func (_e *MockNilRun_Expecter) Foo(nilRun any) *MockNilRun_Foo_Call {
 	return &MockNilRun_Foo_Call{Call: _e.mock.On("Foo", nilRun)}
 }
 
@@ -3308,7 +3313,7 @@ type MockRequester_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - path string
-func (_e *MockRequester_Expecter) Get(path interface{}) *MockRequester_Get_Call {
+func (_e *MockRequester_Expecter) Get(path any) *MockRequester_Get_Call {
 	return &MockRequester_Get_Call{Call: _e.mock.On("Get", path)}
 }
 
@@ -3386,7 +3391,7 @@ type MockRequester2_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - path string
-func (_e *MockRequester2_Expecter) Get(path interface{}) *MockRequester2_Get_Call {
+func (_e *MockRequester2_Expecter) Get(path any) *MockRequester2_Get_Call {
 	return &MockRequester2_Get_Call{Call: _e.mock.On("Get", path)}
 }
 
@@ -3597,7 +3602,7 @@ type MockRequesterArgSameAsImport_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - json1 string
-func (_e *MockRequesterArgSameAsImport_Expecter) Get(json1 interface{}) *MockRequesterArgSameAsImport_Get_Call {
+func (_e *MockRequesterArgSameAsImport_Expecter) Get(json1 any) *MockRequesterArgSameAsImport_Get_Call {
 	return &MockRequesterArgSameAsImport_Get_Call{Call: _e.mock.On("Get", json1)}
 }
 
@@ -3677,7 +3682,7 @@ type MockRequesterArgSameAsNamedImport_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - json1 string
-func (_e *MockRequesterArgSameAsNamedImport_Expecter) Get(json1 interface{}) *MockRequesterArgSameAsNamedImport_Get_Call {
+func (_e *MockRequesterArgSameAsNamedImport_Expecter) Get(json1 any) *MockRequesterArgSameAsNamedImport_Get_Call {
 	return &MockRequesterArgSameAsNamedImport_Get_Call{Call: _e.mock.On("Get", json1)}
 }
 
@@ -3744,7 +3749,7 @@ type MockRequesterArgSameAsPkg_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - test1 string
-func (_e *MockRequesterArgSameAsPkg_Expecter) Get(test1 interface{}) *MockRequesterArgSameAsPkg_Get_Call {
+func (_e *MockRequesterArgSameAsPkg_Expecter) Get(test1 any) *MockRequesterArgSameAsPkg_Get_Call {
 	return &MockRequesterArgSameAsPkg_Get_Call{Call: _e.mock.On("Get", test1)}
 }
 
@@ -3833,7 +3838,7 @@ type MockRequesterArray_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - path string
-func (_e *MockRequesterArray_Expecter) Get(path interface{}) *MockRequesterArray_Get_Call {
+func (_e *MockRequesterArray_Expecter) Get(path any) *MockRequesterArray_Get_Call {
 	return &MockRequesterArray_Get_Call{Call: _e.mock.On("Get", path)}
 }
 
@@ -3912,7 +3917,7 @@ type MockRequesterElided_Get_Call struct {
 // Get is a helper method to define mock.On call
 //   - path string
 //   - url string
-func (_e *MockRequesterElided_Expecter) Get(path interface{}, url interface{}) *MockRequesterElided_Get_Call {
+func (_e *MockRequesterElided_Expecter) Get(path any, url any) *MockRequesterElided_Get_Call {
 	return &MockRequesterElided_Get_Call{Call: _e.mock.On("Get", path, url)}
 }
 
@@ -4077,7 +4082,7 @@ type MockRequesterNS_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - path string
-func (_e *MockRequesterNS_Expecter) Get(path interface{}) *MockRequesterNS_Get_Call {
+func (_e *MockRequesterNS_Expecter) Get(path any) *MockRequesterNS_Get_Call {
 	return &MockRequesterNS_Get_Call{Call: _e.mock.On("Get", path)}
 }
 
@@ -4166,7 +4171,7 @@ type MockRequesterPtr_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - path string
-func (_e *MockRequesterPtr_Expecter) Get(path interface{}) *MockRequesterPtr_Get_Call {
+func (_e *MockRequesterPtr_Expecter) Get(path any) *MockRequesterPtr_Get_Call {
 	return &MockRequesterPtr_Get_Call{Call: _e.mock.On("Get", path)}
 }
 
@@ -4265,7 +4270,7 @@ type MockRequesterReturnElided_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - path string
-func (_e *MockRequesterReturnElided_Expecter) Get(path interface{}) *MockRequesterReturnElided_Get_Call {
+func (_e *MockRequesterReturnElided_Expecter) Get(path any) *MockRequesterReturnElided_Get_Call {
 	return &MockRequesterReturnElided_Get_Call{Call: _e.mock.On("Get", path)}
 }
 
@@ -4325,7 +4330,7 @@ type MockRequesterReturnElided_Put_Call struct {
 
 // Put is a helper method to define mock.On call
 //   - path string
-func (_e *MockRequesterReturnElided_Expecter) Put(path interface{}) *MockRequesterReturnElided_Put_Call {
+func (_e *MockRequesterReturnElided_Expecter) Put(path any) *MockRequesterReturnElided_Put_Call {
 	return &MockRequesterReturnElided_Put_Call{Call: _e.mock.On("Put", path)}
 }
 
@@ -4414,7 +4419,7 @@ type MockRequesterSlice_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - path string
-func (_e *MockRequesterSlice_Expecter) Get(path interface{}) *MockRequesterSlice_Get_Call {
+func (_e *MockRequesterSlice_Expecter) Get(path any) *MockRequesterSlice_Get_Call {
 	return &MockRequesterSlice_Get_Call{Call: _e.mock.On("Get", path)}
 }
 
@@ -4558,9 +4563,9 @@ type MockRequesterVariadicOneArgument_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - values ...string
-func (_e *MockRequesterVariadicOneArgument_Expecter) Get(values ...interface{}) *MockRequesterVariadicOneArgument_Get_Call {
+func (_e *MockRequesterVariadicOneArgument_Expecter) Get(values ...any) *MockRequesterVariadicOneArgument_Get_Call {
 	return &MockRequesterVariadicOneArgument_Get_Call{Call: _e.mock.On("Get",
-		append([]interface{}{}, values...)...)}
+		append([]any{}, values...)...)}
 }
 
 func (_c *MockRequesterVariadicOneArgument_Get_Call) Run(run func(values ...string)) *MockRequesterVariadicOneArgument_Get_Call {
@@ -4619,9 +4624,9 @@ type MockRequesterVariadicOneArgument_MultiWriteToFile_Call struct {
 // MultiWriteToFile is a helper method to define mock.On call
 //   - filename string
 //   - w ...io.Writer
-func (_e *MockRequesterVariadicOneArgument_Expecter) MultiWriteToFile(filename interface{}, w ...interface{}) *MockRequesterVariadicOneArgument_MultiWriteToFile_Call {
+func (_e *MockRequesterVariadicOneArgument_Expecter) MultiWriteToFile(filename any, w ...any) *MockRequesterVariadicOneArgument_MultiWriteToFile_Call {
 	return &MockRequesterVariadicOneArgument_MultiWriteToFile_Call{Call: _e.mock.On("MultiWriteToFile",
-		append([]interface{}{filename}, w...)...)}
+		append([]any{filename}, w...)...)}
 }
 
 func (_c *MockRequesterVariadicOneArgument_MultiWriteToFile_Call) Run(run func(filename string, w ...io.Writer)) *MockRequesterVariadicOneArgument_MultiWriteToFile_Call {
@@ -4684,9 +4689,9 @@ type MockRequesterVariadicOneArgument_OneInterface_Call struct {
 
 // OneInterface is a helper method to define mock.On call
 //   - a ...interface{}
-func (_e *MockRequesterVariadicOneArgument_Expecter) OneInterface(a ...interface{}) *MockRequesterVariadicOneArgument_OneInterface_Call {
+func (_e *MockRequesterVariadicOneArgument_Expecter) OneInterface(a ...any) *MockRequesterVariadicOneArgument_OneInterface_Call {
 	return &MockRequesterVariadicOneArgument_OneInterface_Call{Call: _e.mock.On("OneInterface",
-		append([]interface{}{}, a...)...)}
+		append([]any{}, a...)...)}
 }
 
 func (_c *MockRequesterVariadicOneArgument_OneInterface_Call) Run(run func(a ...interface{})) *MockRequesterVariadicOneArgument_OneInterface_Call {
@@ -4745,9 +4750,9 @@ type MockRequesterVariadicOneArgument_Sprintf_Call struct {
 // Sprintf is a helper method to define mock.On call
 //   - format string
 //   - a ...interface{}
-func (_e *MockRequesterVariadicOneArgument_Expecter) Sprintf(format interface{}, a ...interface{}) *MockRequesterVariadicOneArgument_Sprintf_Call {
+func (_e *MockRequesterVariadicOneArgument_Expecter) Sprintf(format any, a ...any) *MockRequesterVariadicOneArgument_Sprintf_Call {
 	return &MockRequesterVariadicOneArgument_Sprintf_Call{Call: _e.mock.On("Sprintf",
-		append([]interface{}{format}, a...)...)}
+		append([]any{format}, a...)...)}
 }
 
 func (_c *MockRequesterVariadicOneArgument_Sprintf_Call) Run(run func(format string, a ...interface{})) *MockRequesterVariadicOneArgument_Sprintf_Call {
@@ -4810,11 +4815,11 @@ func (_m *MockRequesterVariadic) EXPECT() *MockRequesterVariadic_Expecter {
 // Get provides a mock function for the type MockRequesterVariadic
 func (_mock *MockRequesterVariadic) Get(values ...string) bool {
 	// string
-	_va := make([]interface{}, len(values))
+	_va := make([]any, len(values))
 	for _i := range values {
 		_va[_i] = values[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, _va...)
 	ret := _mock.Called(_ca...)
 
@@ -4838,9 +4843,9 @@ type MockRequesterVariadic_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - values ...string
-func (_e *MockRequesterVariadic_Expecter) Get(values ...interface{}) *MockRequesterVariadic_Get_Call {
+func (_e *MockRequesterVariadic_Expecter) Get(values ...any) *MockRequesterVariadic_Get_Call {
 	return &MockRequesterVariadic_Get_Call{Call: _e.mock.On("Get",
-		append([]interface{}{}, values...)...)}
+		append([]any{}, values...)...)}
 }
 
 func (_c *MockRequesterVariadic_Get_Call) Run(run func(values ...string)) *MockRequesterVariadic_Get_Call {
@@ -4873,11 +4878,11 @@ func (_c *MockRequesterVariadic_Get_Call) RunAndReturn(run func(values ...string
 // MultiWriteToFile provides a mock function for the type MockRequesterVariadic
 func (_mock *MockRequesterVariadic) MultiWriteToFile(filename string, w ...io.Writer) string {
 	// io.Writer
-	_va := make([]interface{}, len(w))
+	_va := make([]any, len(w))
 	for _i := range w {
 		_va[_i] = w[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, filename)
 	_ca = append(_ca, _va...)
 	ret := _mock.Called(_ca...)
@@ -4903,9 +4908,9 @@ type MockRequesterVariadic_MultiWriteToFile_Call struct {
 // MultiWriteToFile is a helper method to define mock.On call
 //   - filename string
 //   - w ...io.Writer
-func (_e *MockRequesterVariadic_Expecter) MultiWriteToFile(filename interface{}, w ...interface{}) *MockRequesterVariadic_MultiWriteToFile_Call {
+func (_e *MockRequesterVariadic_Expecter) MultiWriteToFile(filename any, w ...any) *MockRequesterVariadic_MultiWriteToFile_Call {
 	return &MockRequesterVariadic_MultiWriteToFile_Call{Call: _e.mock.On("MultiWriteToFile",
-		append([]interface{}{filename}, w...)...)}
+		append([]any{filename}, w...)...)}
 }
 
 func (_c *MockRequesterVariadic_MultiWriteToFile_Call) Run(run func(filename string, w ...io.Writer)) *MockRequesterVariadic_MultiWriteToFile_Call {
@@ -4942,8 +4947,13 @@ func (_c *MockRequesterVariadic_MultiWriteToFile_Call) RunAndReturn(run func(fil
 
 // OneInterface provides a mock function for the type MockRequesterVariadic
 func (_mock *MockRequesterVariadic) OneInterface(a ...interface{}) bool {
-	var _ca []interface{}
-	_ca = append(_ca, a...)
+	// interface{}
+	_va := make([]any, len(a))
+	for _i := range a {
+		_va[_i] = a[_i]
+	}
+	var _ca []any
+	_ca = append(_ca, _va...)
 	ret := _mock.Called(_ca...)
 
 	if len(ret) == 0 {
@@ -4966,9 +4976,9 @@ type MockRequesterVariadic_OneInterface_Call struct {
 
 // OneInterface is a helper method to define mock.On call
 //   - a ...interface{}
-func (_e *MockRequesterVariadic_Expecter) OneInterface(a ...interface{}) *MockRequesterVariadic_OneInterface_Call {
+func (_e *MockRequesterVariadic_Expecter) OneInterface(a ...any) *MockRequesterVariadic_OneInterface_Call {
 	return &MockRequesterVariadic_OneInterface_Call{Call: _e.mock.On("OneInterface",
-		append([]interface{}{}, a...)...)}
+		append([]any{}, a...)...)}
 }
 
 func (_c *MockRequesterVariadic_OneInterface_Call) Run(run func(a ...interface{})) *MockRequesterVariadic_OneInterface_Call {
@@ -5000,9 +5010,14 @@ func (_c *MockRequesterVariadic_OneInterface_Call) RunAndReturn(run func(a ...in
 
 // Sprintf provides a mock function for the type MockRequesterVariadic
 func (_mock *MockRequesterVariadic) Sprintf(format string, a ...interface{}) string {
-	var _ca []interface{}
+	// interface{}
+	_va := make([]any, len(a))
+	for _i := range a {
+		_va[_i] = a[_i]
+	}
+	var _ca []any
 	_ca = append(_ca, format)
-	_ca = append(_ca, a...)
+	_ca = append(_ca, _va...)
 	ret := _mock.Called(_ca...)
 
 	if len(ret) == 0 {
@@ -5026,9 +5041,9 @@ type MockRequesterVariadic_Sprintf_Call struct {
 // Sprintf is a helper method to define mock.On call
 //   - format string
 //   - a ...interface{}
-func (_e *MockRequesterVariadic_Expecter) Sprintf(format interface{}, a ...interface{}) *MockRequesterVariadic_Sprintf_Call {
+func (_e *MockRequesterVariadic_Expecter) Sprintf(format any, a ...any) *MockRequesterVariadic_Sprintf_Call {
 	return &MockRequesterVariadic_Sprintf_Call{Call: _e.mock.On("Sprintf",
-		append([]interface{}{format}, a...)...)}
+		append([]any{format}, a...)...)}
 }
 
 func (_c *MockRequesterVariadic_Sprintf_Call) Run(run func(format string, a ...interface{})) *MockRequesterVariadic_Sprintf_Call {
@@ -5160,7 +5175,7 @@ type MockExample_B_Call struct {
 
 // B is a helper method to define mock.On call
 //   - fixtureshttp string
-func (_e *MockExample_Expecter) B(fixtureshttp interface{}) *MockExample_B_Call {
+func (_e *MockExample_Expecter) B(fixtureshttp any) *MockExample_B_Call {
 	return &MockExample_B_Call{Call: _e.mock.On("B", fixtureshttp)}
 }
 
@@ -5211,7 +5226,7 @@ type MockExample_C_Call struct {
 
 // C is a helper method to define mock.On call
 //   - fixtureshttp string
-func (_e *MockExample_Expecter) C(fixtureshttp interface{}) *MockExample_C_Call {
+func (_e *MockExample_Expecter) C(fixtureshttp any) *MockExample_C_Call {
 	return &MockExample_C_Call{Call: _e.mock.On("C", fixtureshttp)}
 }
 
@@ -5389,7 +5404,7 @@ type MockStructWithTag_MethodA_Call struct {
 
 // MethodA is a helper method to define mock.On call
 //   - v *struct{FieldA int "json:\"field_a\""; FieldB int "json:\"field_b\" xml:\"field_b\""}
-func (_e *MockStructWithTag_Expecter) MethodA(v interface{}) *MockStructWithTag_MethodA_Call {
+func (_e *MockStructWithTag_Expecter) MethodA(v any) *MockStructWithTag_MethodA_Call {
 	return &MockStructWithTag_MethodA_Call{Call: _e.mock.On("MethodA", v)}
 }
 
@@ -5474,7 +5489,7 @@ type MockUnsafeInterface_Do_Call struct {
 
 // Do is a helper method to define mock.On call
 //   - ptr *unsafe.Pointer
-func (_e *MockUnsafeInterface_Expecter) Do(ptr interface{}) *MockUnsafeInterface_Do_Call {
+func (_e *MockUnsafeInterface_Expecter) Do(ptr any) *MockUnsafeInterface_Do_Call {
 	return &MockUnsafeInterface_Do_Call{Call: _e.mock.On("Do", ptr)}
 }
 
@@ -5553,7 +5568,7 @@ type MockVariadic_VariadicFunction_Call struct {
 // VariadicFunction is a helper method to define mock.On call
 //   - str string
 //   - vFunc VariadicFunction
-func (_e *MockVariadic_Expecter) VariadicFunction(str interface{}, vFunc interface{}) *MockVariadic_VariadicFunction_Call {
+func (_e *MockVariadic_Expecter) VariadicFunction(str any, vFunc any) *MockVariadic_VariadicFunction_Call {
 	return &MockVariadic_VariadicFunction_Call{Call: _e.mock.On("VariadicFunction", str, vFunc)}
 }
 
@@ -5638,7 +5653,7 @@ type MockVariadicReturnFunc_SampleMethod_Call struct {
 
 // SampleMethod is a helper method to define mock.On call
 //   - str string
-func (_e *MockVariadicReturnFunc_Expecter) SampleMethod(str interface{}) *MockVariadicReturnFunc_SampleMethod_Call {
+func (_e *MockVariadicReturnFunc_Expecter) SampleMethod(str any) *MockVariadicReturnFunc_SampleMethod_Call {
 	return &MockVariadicReturnFunc_SampleMethod_Call{Call: _e.mock.On("SampleMethod", str)}
 }
 
@@ -5695,11 +5710,11 @@ func (_m *MockVariadicWithMultipleReturnsUnrollVariadic) EXPECT() *MockVariadicW
 // Foo provides a mock function for the type MockVariadicWithMultipleReturnsUnrollVariadic
 func (_mock *MockVariadicWithMultipleReturnsUnrollVariadic) Foo(one string, two ...string) (string, error) {
 	// string
-	_va := make([]interface{}, len(two))
+	_va := make([]any, len(two))
 	for _i := range two {
 		_va[_i] = two[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, one)
 	_ca = append(_ca, _va...)
 	ret := _mock.Called(_ca...)
@@ -5734,9 +5749,9 @@ type MockVariadicWithMultipleReturnsUnrollVariadic_Foo_Call struct {
 // Foo is a helper method to define mock.On call
 //   - one string
 //   - two ...string
-func (_e *MockVariadicWithMultipleReturnsUnrollVariadic_Expecter) Foo(one interface{}, two ...interface{}) *MockVariadicWithMultipleReturnsUnrollVariadic_Foo_Call {
+func (_e *MockVariadicWithMultipleReturnsUnrollVariadic_Expecter) Foo(one any, two ...any) *MockVariadicWithMultipleReturnsUnrollVariadic_Foo_Call {
 	return &MockVariadicWithMultipleReturnsUnrollVariadic_Foo_Call{Call: _e.mock.On("Foo",
-		append([]interface{}{one}, two...)...)}
+		append([]any{one}, two...)...)}
 }
 
 func (_c *MockVariadicWithMultipleReturnsUnrollVariadic_Foo_Call) Run(run func(one string, two ...string)) *MockVariadicWithMultipleReturnsUnrollVariadic_Foo_Call {
@@ -5838,9 +5853,9 @@ type MockVariadicWithMultipleReturns_Foo_Call struct {
 // Foo is a helper method to define mock.On call
 //   - one string
 //   - two ...string
-func (_e *MockVariadicWithMultipleReturns_Expecter) Foo(one interface{}, two ...interface{}) *MockVariadicWithMultipleReturns_Foo_Call {
+func (_e *MockVariadicWithMultipleReturns_Expecter) Foo(one any, two ...any) *MockVariadicWithMultipleReturns_Foo_Call {
 	return &MockVariadicWithMultipleReturns_Foo_Call{Call: _e.mock.On("Foo",
-		append([]interface{}{one}, two...)...)}
+		append([]any{one}, two...)...)}
 }
 
 func (_c *MockVariadicWithMultipleReturns_Foo_Call) Run(run func(one string, two ...string)) *MockVariadicWithMultipleReturns_Foo_Call {
@@ -5903,11 +5918,11 @@ func (_m *MockVariadicWithNoReturns) EXPECT() *MockVariadicWithNoReturns_Expecte
 // Foo provides a mock function for the type MockVariadicWithNoReturns
 func (_mock *MockVariadicWithNoReturns) Foo(one string, two ...string) {
 	// string
-	_va := make([]interface{}, len(two))
+	_va := make([]any, len(two))
 	for _i := range two {
 		_va[_i] = two[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, one)
 	_ca = append(_ca, _va...)
 	_mock.Called(_ca...)
@@ -5922,9 +5937,9 @@ type MockVariadicWithNoReturns_Foo_Call struct {
 // Foo is a helper method to define mock.On call
 //   - one string
 //   - two ...string
-func (_e *MockVariadicWithNoReturns_Expecter) Foo(one interface{}, two ...interface{}) *MockVariadicWithNoReturns_Foo_Call {
+func (_e *MockVariadicWithNoReturns_Expecter) Foo(one any, two ...any) *MockVariadicWithNoReturns_Foo_Call {
 	return &MockVariadicWithNoReturns_Foo_Call{Call: _e.mock.On("Foo",
-		append([]interface{}{one}, two...)...)}
+		append([]any{one}, two...)...)}
 }
 
 func (_c *MockVariadicWithNoReturns_Foo_Call) Run(run func(one string, two ...string)) *MockVariadicWithNoReturns_Foo_Call {

--- a/internal/fixtures/replace_type_pointers/mocks_testify_replace_type_pointers_test.go
+++ b/internal/fixtures/replace_type_pointers/mocks_testify_replace_type_pointers_test.go
@@ -61,7 +61,7 @@ type MockInterfaceWithPointers_BarFunc_Call struct {
 
 // BarFunc is a helper method to define mock.On call
 //   - bar Bar
-func (_e *MockInterfaceWithPointers_Expecter) BarFunc(bar interface{}) *MockInterfaceWithPointers_BarFunc_Call {
+func (_e *MockInterfaceWithPointers_Expecter) BarFunc(bar any) *MockInterfaceWithPointers_BarFunc_Call {
 	return &MockInterfaceWithPointers_BarFunc_Call{Call: _e.mock.On("BarFunc", bar)}
 }
 
@@ -114,7 +114,7 @@ type MockInterfaceWithPointers_FooFunc_Call struct {
 
 // FooFunc is a helper method to define mock.On call
 //   - foo *Bar
-func (_e *MockInterfaceWithPointers_Expecter) FooFunc(foo interface{}) *MockInterfaceWithPointers_FooFunc_Call {
+func (_e *MockInterfaceWithPointers_Expecter) FooFunc(foo any) *MockInterfaceWithPointers_FooFunc_Call {
 	return &MockInterfaceWithPointers_FooFunc_Call{Call: _e.mock.On("FooFunc", foo)}
 }
 

--- a/internal/fixtures/type_alias/mocks_testify_type_alias_test.go
+++ b/internal/fixtures/type_alias/mocks_testify_type_alias_test.go
@@ -195,7 +195,7 @@ type MockInterface2_F_Call struct {
 //   - v Type
 //   - v1 S
 //   - s subpkg.S
-func (_e *MockInterface2_Expecter) F(v interface{}, v1 interface{}, s interface{}) *MockInterface2_F_Call {
+func (_e *MockInterface2_Expecter) F(v any, v1 any, s any) *MockInterface2_F_Call {
 	return &MockInterface2_F_Call{Call: _e.mock.On("F", v, v1, s)}
 }
 

--- a/internal/mock_testify.templ
+++ b/internal/mock_testify.templ
@@ -95,15 +95,15 @@ func (_mock *{{$mock.StructName}}{{ $mock.TypeInstantiation }}) {{$method.Name}}
 	{{- $variadicArgsName := $lastParam.Var.Name }}
 	{{- $strippedTypeString := trimPrefix "..." $lastParam.TypeStringEllipsis }}
 
-	{{- if and (ne $strippedTypeString "interface{}") (ne $strippedTypeString "any") }}
+	{{- if and (ne $strippedTypeString "any") (ne $strippedTypeString "any") }}
 	// {{ $strippedTypeString }}
-	_va := make([]interface{}, len({{- $lastParam.Var.Name }}))
+	_va := make([]any, len({{- $lastParam.Var.Name }}))
 	for _i := range {{ $lastParam.Var.Name }} {
 		_va[_i] = {{ $lastParam.Var.Name }}[_i]
 	}
 		{{- $variadicArgsName = "_va" }}
 	{{- end }}
-	var _ca []interface{}
+	var _ca []any
 	{{- if gt (len $method.Params) 1 }}
 	_ca = append(_ca, {{ $method.ArgCallListSlice 0 (len $method.Params | add -1) }})
 	{{- end }}
@@ -163,12 +163,12 @@ type {{ $ExpecterCallNameConstraint }} struct {
 {{- range $method.Params }}
 //  - {{.Var.Name}} {{.TypeStringEllipsis}}
 {{- end}}
-func (_e *{{ $expecterNameInstantiated }}) {{ $method.Name }}({{ range $method.Params }}{{ .Var.Name }} {{ if .Variadic }}...{{end}}interface{}, {{ end }}) *{{ $ExpecterCallNameInstantiated }} {
+func (_e *{{ $expecterNameInstantiated }}) {{ $method.Name }}({{ range $method.Params }}{{ .Var.Name }} {{ if .Variadic }}...{{end}}any, {{ end }}) *{{ $ExpecterCallNameInstantiated }} {
 	return &{{ $ExpecterCallNameInstantiated }}{Call: _e.mock.On("{{$method.Name}}",
 			{{- if not $method.IsVariadic }}
 				{{- range $method.Params}}{{.Var.Name}},{{end}}
 			{{- else }}
-				append([]interface{}{
+				append([]any{
 					{{- range $i, $param := $method.Params }}
 						{{- if (lt $i (len $method.Params | add -1 ))}} {{ $param.Var.Name }},
 						{{- else }} }, {{ $param.Var.Name }}...


### PR DESCRIPTION
Description
-------------

Replace 'interface{}' (old syntax) with 'any', especially for Testify. Tested.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [x] 1.26

How Has This Been Tested?
---------------------------

- No failed unit tests.
- Built the binary locally and tested with my private project.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
