### PR TITLE
fix: correct typos in comments and docs

### DIFF
--- a/docs/v3.md
+++ b/docs/v3.md
@@ -128,7 +128,7 @@ This command will return two results:
 
 ## Config Templates
 
-Template functions used in configuration files have changed. The order of arugments for functions that take input strings is swapped. For example, in v2 the [`trimSuffix` function](https://github.com/vektra/mockery/blob/v2.53.3/pkg/outputter.go#L49) was set to the `strings.TrimSuffix` function from the stdlib. In v3, the argument orders are swapped, for example:
+Template functions used in configuration files have changed. The order of arguments for functions that take input strings is swapped. For example, in v2 the [`trimSuffix` function](https://github.com/vektra/mockery/blob/v2.53.3/pkg/outputter.go#L49) was set to the `strings.TrimSuffix` function from the stdlib. In v3, the argument orders are swapped, for example:
 
 ```go
 "trimSuffix":  func(suffix string, s string) string { return strings.TrimSuffix(s, suffix) },

--- a/internal/cmd/migrate.go
+++ b/internal/cmd/migrate.go
@@ -62,7 +62,7 @@ func NewMigrateCmd() *cobra.Command {
 		},
 	}
 	flags := cmd.PersistentFlags()
-	flags.String("outfile", ".mockery_v3.yml", "Location of the ouptut v3 file.")
+	flags.String("outfile", ".mockery_v3.yml", "Location of the output v3 file.")
 
 	return cmd
 }

--- a/internal/cmd/mockery.go
+++ b/internal/cmd/mockery.go
@@ -220,7 +220,7 @@ func (r *RootApp) Run() error {
 	//
 	// NOTE: We do that here without relying on parser, because parses iterates
 	// over existing go files and interfaces, while user could've had a typo in
-	// interface or pacakge name, making it impossible for parser to find these
+	// interface or package name, making it impossible for parser to find these
 	// files/interfaces in the first place.
 	log.Debug().Msg("Making seen map...")
 	missingMap := make(map[string]map[string]struct{}, len(configuredPackages))

--- a/template/param.go
+++ b/template/param.go
@@ -42,7 +42,7 @@ func (p Param) MethodArgNoName() string {
 }
 
 // CallName returns the string representation of the parameter to be
-// used for a method call. For a variadic paramter, it will be of the
+// used for a method call. For a variadic parameter, it will be of the
 // format 'foos...' if ellipsis is true.
 func (p Param) CallName(ellipsis bool) string {
 	if ellipsis && p.Variadic {

--- a/template_funcs/funcmap.go
+++ b/template_funcs/funcmap.go
@@ -1,6 +1,6 @@
 // Package shared provides variables/objects that need to be shared
 // across multiple packages. The main purpose is to resolve cyclical imports
-// arising from multiple packages needing to share common utilies.
+// arising from multiple packages needing to share common utilities.
 package template_funcs
 
 import (


### PR DESCRIPTION
Fixed five minor typos found in comments and documentation:

- `paramter` → `parameter` in `template/param.go` (godoc comment)
- `ouptut` → `output` in `internal/cmd/migrate.go` (CLI flag description)
- `pacakge` → `package` in `internal/cmd/mockery.go` (code comment)
- `utilies` → `utilities` in `template_funcs/funcmap.go` (package comment)
- `arugments` → `arguments` in `docs/v3.md`

Found with codespell.

Signed-off-by: maxtaran2010 <ocotifuzo727@gmail.com>