### PR TITLE
Match interface{} as well as any

### DIFF
--- a/internal/fixtures/mocks_testify_test_test.go
+++ b/internal/fixtures/mocks_testify_test_test.go
@@ -1369,14 +1369,9 @@ func (_c *MockExpecter_Variadic_Call) RunAndReturn(run func(ints ...int) error) 
 
 // VariadicMany provides a mock function for the type MockExpecter
 func (_mock *MockExpecter) VariadicMany(i int, a string, intfs ...interface{}) error {
-	// interface{}
-	_va := make([]any, len(intfs))
-	for _i := range intfs {
-		_va[_i] = intfs[_i]
-	}
 	var _ca []any
 	_ca = append(_ca, i, a)
-	_ca = append(_ca, _va...)
+	_ca = append(_ca, intfs...)
 	ret := _mock.Called(_ca...)
 
 	if len(ret) == 0 {
@@ -4947,13 +4942,8 @@ func (_c *MockRequesterVariadic_MultiWriteToFile_Call) RunAndReturn(run func(fil
 
 // OneInterface provides a mock function for the type MockRequesterVariadic
 func (_mock *MockRequesterVariadic) OneInterface(a ...interface{}) bool {
-	// interface{}
-	_va := make([]any, len(a))
-	for _i := range a {
-		_va[_i] = a[_i]
-	}
 	var _ca []any
-	_ca = append(_ca, _va...)
+	_ca = append(_ca, a...)
 	ret := _mock.Called(_ca...)
 
 	if len(ret) == 0 {
@@ -5010,14 +5000,9 @@ func (_c *MockRequesterVariadic_OneInterface_Call) RunAndReturn(run func(a ...in
 
 // Sprintf provides a mock function for the type MockRequesterVariadic
 func (_mock *MockRequesterVariadic) Sprintf(format string, a ...interface{}) string {
-	// interface{}
-	_va := make([]any, len(a))
-	for _i := range a {
-		_va[_i] = a[_i]
-	}
 	var _ca []any
 	_ca = append(_ca, format)
-	_ca = append(_ca, _va...)
+	_ca = append(_ca, a...)
 	ret := _mock.Called(_ca...)
 
 	if len(ret) == 0 {

--- a/internal/mock_testify.templ
+++ b/internal/mock_testify.templ
@@ -95,7 +95,7 @@ func (_mock *{{$mock.StructName}}{{ $mock.TypeInstantiation }}) {{$method.Name}}
 	{{- $variadicArgsName := $lastParam.Var.Name }}
 	{{- $strippedTypeString := trimPrefix "..." $lastParam.TypeStringEllipsis }}
 
-	{{- if and (ne $strippedTypeString "any") (ne $strippedTypeString "any") }}
+	{{- if and (ne $strippedTypeString "interface{}") (ne $strippedTypeString "any") }}
 	// {{ $strippedTypeString }}
 	_va := make([]any, len({{- $lastParam.Var.Name }}))
 	for _i := range {{ $lastParam.Var.Name }} {


### PR DESCRIPTION
Description
-------------

The switch from `interface{}` to `any` in commit 775a28802 converted an `interface{}`/`any` match to `any`/`any`. This restores the pre-existing match pair and restores the previous behaviour with variadic functions involving `interface{}` (see `mocks_testify_test_test.go`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [x] 1.26

How Has This Been Tested?
---------------------------

I ran the Mockery tests (which updated `mocks_testify_test_test.go`) and checked the mocks in Kubernetes.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
