### PR TITLE
fix: report unparsable `exclude-subpkg-regex` instead of panicking

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -121,7 +121,7 @@ tasks:
   test:
     deps: [tools.gotestsum]
     cmds:
-      - GOWORK=off ./tools/gotestsum{{exeExt}} --format testname -- -v -coverprofile=coverage.txt ./internal/... ./template_funcs/... ./template/...
+      - GOWORK=off ./tools/gotestsum{{exeExt}} --format testname -- -v -coverprofile=coverage.txt ./config/... ./internal/... ./template_funcs/... ./template/...
     desc: run unit tests
     generates:
       - coverage.txt

--- a/config/config.go
+++ b/config/config.go
@@ -361,7 +361,11 @@ func (c *RootConfig) Initialize(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("getting package config: %w", err)
 			}
-			if recursivePkgConfig.Config.ShouldExcludeSubpkg(subpkg) {
+			excluded, err := recursivePkgConfig.Config.ShouldExcludeSubpkg(subpkg)
+			if err != nil {
+				return err
+			}
+			if excluded {
 				pkgLog.Debug().Msg("package was marked for exclusion")
 				continue
 			}
@@ -667,17 +671,21 @@ func (c *Config) FilePath() string {
 	return filepath.ToSlash(filepath.Clean(filepath.Join(*c.Dir, *c.FileName)))
 }
 
-func (c *Config) ShouldExcludeSubpkg(pkgPath string) bool {
+// ShouldExcludeSubpkg reports whether pkgPath matches any of the
+// `exclude-subpkg-regex` patterns. An unparsable pattern is returned as an
+// error so it surfaces as a configuration failure, the same way
+// `include-interface-regex` and `exclude-interface-regex` do.
+func (c *Config) ShouldExcludeSubpkg(pkgPath string) (bool, error) {
 	for _, regex := range c.ExcludeSubpkgRegex {
 		matched, err := regexp.MatchString(regex, pkgPath)
 		if err != nil {
-			panic(err)
+			return false, fmt.Errorf("evaluating `exclude-subpkg-regex`: %w", err)
 		}
 		if matched {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 var ErrInfiniteLoop = fmt.Errorf("infinite loop in template variables detected")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -290,3 +290,76 @@ func TestIsPathOutsideCurrentGoModRepo(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, insideRepo)
 }
+
+func TestShouldExcludeSubpkg(t *testing.T) {
+	tests := []struct {
+		name    string
+		regexes []string
+		pkgPath string
+		want    bool
+		wantErr string
+	}{
+		{
+			name:    "no patterns configured",
+			pkgPath: "github.com/foo/bar/subpkg",
+			want:    false,
+		},
+		{
+			name:    "matching pattern",
+			regexes: []string{"subpkg2"},
+			pkgPath: "github.com/foo/bar/subpkg2",
+			want:    true,
+		},
+		{
+			name:    "non-matching pattern",
+			regexes: []string{"subpkg2"},
+			pkgPath: "github.com/foo/bar/subpkg1",
+			want:    false,
+		},
+		{
+			name:    "unparsable pattern",
+			regexes: []string{"("},
+			pkgPath: "github.com/foo/bar/subpkg1",
+			wantErr: "evaluating `exclude-subpkg-regex`: error parsing regexp: missing closing ): `(`",
+		},
+		{
+			name:    "unparsable pattern after a match",
+			regexes: []string{"subpkg1", "("},
+			pkgPath: "github.com/foo/bar/subpkg1",
+			want:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{ExcludeSubpkgRegex: tt.regexes}
+			got, err := c.ShouldExcludeSubpkg(tt.pkgPath)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				assert.False(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNewRootConfigUnparsableExcludeSubpkgRegex(t *testing.T) {
+	configFile := path.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+packages:
+  github.com/vektra/mockery/v3/internal/fixtures/recursive_generation:
+    config:
+      recursive: True
+      exclude-subpkg-regex:
+        - "("
+`), 0o600))
+
+	flags := pflag.NewFlagSet("test", pflag.ExitOnError)
+	flags.String("config", "", "")
+
+	require.NoError(t, flags.Parse([]string{"--config", configFile}))
+	_, _, err := NewRootConfig(context.Background(), flags)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "evaluating `exclude-subpkg-regex`")
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -232,7 +232,9 @@ func TestBuildTemplateData(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	assert.Equal(t, "/config", data.ConfigDir)
+	// ConfigDir comes from filepath.Dir, which cleans to the platform's
+	// separator, so "/config" is spelled the platform's way to compare.
+	assert.Equal(t, filepath.FromSlash("/config"), data.ConfigDir)
 	assert.Equal(t, fmt.Sprintf("%s/internal/foo", wd), data.InterfaceDir)
 	assert.Equal(t, "internal/foo", data.InterfaceDirRelative)
 	assert.Equal(t, fmt.Sprintf("%s/internal/foo/bar.go", wd), data.InterfaceFile)


### PR DESCRIPTION
Description
-------------

- Fixes #1177

`ShouldExcludeSubpkg` has one caller, inside a function that already returns `error`, so the failure has a path to the user without new plumbing.

Rejected alternative: compiling the patterns during config validation. That leaves the `panic` reachable on any other call path and splits the pattern lifecycle across two places. Returning the error matches `ShouldGenerateInterface`, which wraps the identical `regexp.MatchString` failure for `include-interface-regex`.

Residual: `ShouldExcludeSubpkg` is exported and its signature changes. The package doc states the package is not meant for external import and does not guarantee backwards compatibility of its methods.

On the `Taskfile.yml` line: the `test` task ran `./internal/... ./template_funcs/... ./template/...`, so `config/config_test.go` and its 7 existing test functions stopped running when b847fc8f moved the package from `template/` into `config/`. Adding `./config/...` is what makes the regression test execute in CI. Splitting it out is fine if you prefer.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Neither type box is ticked because the change fixes a bug but alters an exported signature. Your call on which applies given the package doc.

Version of Go used when building/testing:
---------------------------------------------

- [ ] 1.22
- [ ] 1.23

Neither. Built and tested with `go1.26.3 darwin/arm64`.

How Has This Been Tested?
---------------------------

Base ffa1c3f8, golangci-lint v2.13.1 from `tools/go.mod`.

- Lint: 0 issues on a clean checkout and 0 after.
- `GOWORK=off go test -count=1 ./config/... ./internal/... ./template_funcs/... ./template/...` and `./e2e/...` pass. `bash ./e2e/run_all.sh` then `git status` leaves the tree clean.
- Anti-vacuity: restoring `panic(err)` under the new signature fails `TestShouldExcludeSubpkg/unparsable_pattern` and `TestNewRootConfigUnparsableExcludeSubpkgRegex`. The other three table cases pin current behaviour rather than add coverage.
- Reproducer from #1177 now prints ``FTL app failed error="initializing root config: evaluating `exclude-subpkg-regex`: error parsing regexp: missing closing ): `(`"`` and exits nonzero.

Checklist
-----------

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

The unticked boxes are review judgements rather than measurements, so they are left for you.
