### PR TITLE
fix: mark testify mock constructors and cleanup as helpers

### DIFF
--- a/github.com/LandonTClipp/example-go-repo/mocks_testify_foo_test.go
+++ b/github.com/LandonTClipp/example-go-repo/mocks_testify_foo_test.go
@@ -16,10 +16,19 @@ func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockFoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/cmd/mocks_testify_cmd_test.go
+++ b/internal/cmd/mocks_testify_cmd_test.go
@@ -16,10 +16,19 @@ func newMockargGetter(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *mockargGetter {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &mockargGetter{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/auto_generated_skip/mocks_testify_autogeneratedskip_test.go
+++ b/internal/fixtures/auto_generated_skip/mocks_testify_autogeneratedskip_test.go
@@ -16,10 +16,19 @@ func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockFoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/buildtag/comment/mocks_testify_comment_test.go
+++ b/internal/fixtures/buildtag/comment/mocks_testify_comment_test.go
@@ -16,10 +16,19 @@ func NewMockIfaceWithBuildTagInComment(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockIfaceWithBuildTagInComment {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockIfaceWithBuildTagInComment{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/constructor_helpers_test.go
+++ b/internal/fixtures/constructor_helpers_test.go
@@ -1,0 +1,88 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockConstructorReportsCaller(t *testing.T) {
+	const childProcess = "MOCKERY_TEST_CONSTRUCTOR_HELPER"
+	if os.Getenv(childProcess) == "1" {
+		_, file, line, ok := runtime.Caller(0)
+		require.True(t, ok)
+		t.Logf("expected location: %s:%d", filepath.Base(file), line+3)
+		m := NewMockRequester(t)
+		m.EXPECT().Get("missing").Return("", nil).Once()
+		return
+	}
+
+	executable, err := os.Executable()
+	require.NoError(t, err)
+	cmd := exec.Command(executable, "-test.run=^TestMockConstructorReportsCaller$", "-test.v")
+	cmd.Env = append(os.Environ(), childProcess+"=1")
+	out, err := cmd.CombinedOutput()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr, "%s", out)
+	require.Equal(t, 1, exitErr.ExitCode(), "%s", out)
+
+	location := regexp.MustCompile(`expected location: (constructor_helpers_test\.go:\d+)`).FindSubmatch(out)
+	require.Len(t, location, 2, "%s", out)
+	assert.Contains(t, string(out), string(location[1])+": FAIL: 0 out of 1 expectation(s) were met.")
+}
+
+func TestMockConstructorWithoutHelper(t *testing.T) {
+	for _, fulfilled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("fulfilled=%t", fulfilled), func(t *testing.T) {
+			legacy := &constructorTestingT{}
+			m := NewMockRequester(legacy)
+			m.EXPECT().Get("request").Return("response", nil).Once()
+			if fulfilled {
+				response, err := m.Get("request")
+				require.NoError(t, err)
+				assert.Equal(t, "response", response)
+			}
+
+			require.NotNil(t, legacy.cleanup)
+			legacy.cleanup()
+			if fulfilled {
+				assert.Empty(t, legacy.errors)
+			} else {
+				require.Len(t, legacy.errors, 1)
+				assert.Contains(t, legacy.errors[0], "0 out of 1 expectation(s) were met")
+			}
+		})
+	}
+}
+
+func TestMockConstructorTypeParams(t *testing.T) {
+	m := NewMockConstructorTypeParams[string, bool](t)
+	m.EXPECT().Get().Return("response").Once()
+	assert.Equal(t, "response", m.Get())
+}
+
+type constructorTestingT struct {
+	cleanup func()
+	errors  []string
+}
+
+func (t *constructorTestingT) Cleanup(f func()) {
+	t.cleanup = f
+}
+
+func (t *constructorTestingT) Logf(string, ...any) {}
+
+func (t *constructorTestingT) Errorf(format string, args ...any) {
+	t.errors = append(t.errors, fmt.Sprintf(format, args...))
+}
+
+func (t *constructorTestingT) FailNow() {
+	panic("unexpected FailNow")
+}

--- a/internal/fixtures/directive_comments/mocks_testify_directive_comments_test.go
+++ b/internal/fixtures/directive_comments/mocks_testify_directive_comments_test.go
@@ -18,10 +18,19 @@ func NewMockRequester(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequester {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequester{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -105,10 +114,19 @@ func NewFunServer(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *FunServer {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &FunServer{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -178,10 +196,19 @@ func NewInterfaceWithoutGenerateFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *InterfaceWithoutGenerateFoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &InterfaceWithoutGenerateFoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/directive_comments/server_with_different_file.go
+++ b/internal/fixtures/directive_comments/server_with_different_file.go
@@ -18,10 +18,19 @@ func NewFunServerWithDifferentFile(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *FunServerWithDifferentFile {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &FunServerWithDifferentFile{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -91,10 +100,19 @@ func NewAnotherFunServerWithDifferentFile(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *AnotherFunServerWithDifferentFile {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &AnotherFunServerWithDifferentFile{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/empty_return/mocks_testify_empty_return_test.go
+++ b/internal/fixtures/empty_return/mocks_testify_empty_return_test.go
@@ -16,10 +16,19 @@ func NewMockEmptyReturn(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockEmptyReturn {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockEmptyReturn{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/example_project/mocks_testify_example_project_test.go
+++ b/internal/fixtures/example_project/mocks_testify_example_project_test.go
@@ -17,10 +17,19 @@ func NewMockRoot(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRoot {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRoot{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -139,10 +148,19 @@ func NewMockStringer(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockStringer {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockStringer{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/example_project/replace_type/mocks_testify_replace_type_test.go
+++ b/internal/fixtures/example_project/replace_type/mocks_testify_replace_type_test.go
@@ -18,10 +18,19 @@ func NewMockRType(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRType {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRType{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -125,10 +134,19 @@ func NewRTypeReplaced1(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *RTypeReplaced1 {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &RTypeReplaced1{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/generic.go
+++ b/internal/fixtures/generic.go
@@ -50,3 +50,7 @@ type ReplaceGeneric[
 type ReplaceGenericSelf[T any] interface {
 	A() T
 }
+
+type ConstructorTypeParams[helper, ok any] interface {
+	Get() string
+}

--- a/internal/fixtures/iface_new_type/mocks_testify_iface_new_type_test.go
+++ b/internal/fixtures/iface_new_type/mocks_testify_iface_new_type_test.go
@@ -16,10 +16,19 @@ func NewMockInterface1(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockInterface1 {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockInterface1{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -76,10 +85,19 @@ func NewMockInterface2(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockInterface2 {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockInterface2{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -136,10 +154,19 @@ func NewMockInterface3(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockInterface3 {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockInterface3{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/iface_typed_param/mocks_testify_iface_typed_param_test.go
+++ b/internal/fixtures/iface_typed_param/mocks_testify_iface_typed_param_test.go
@@ -18,10 +18,19 @@ func NewMockGetterIfaceTypedParam[T io.Reader](t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockGetterIfaceTypedParam[T] {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockGetterIfaceTypedParam[T]{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/iface_typed_param_lowercase/mocks_testify_iface_typed_param_lowercase_test.go
+++ b/internal/fixtures/iface_typed_param_lowercase/mocks_testify_iface_typed_param_lowercase_test.go
@@ -16,10 +16,19 @@ func NewMockGetterIfaceTypedParam[a comparable](t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockGetterIfaceTypedParam[a] {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockGetterIfaceTypedParam[a]{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/include_auto_generated/mocks_testify_includeautogenerated_test.go
+++ b/internal/fixtures/include_auto_generated/mocks_testify_includeautogenerated_test.go
@@ -16,10 +16,19 @@ func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockFoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/index_list_expr/mocks_testify_index_list_expr_test.go
+++ b/internal/fixtures/index_list_expr/mocks_testify_index_list_expr_test.go
@@ -16,10 +16,19 @@ func NewMockGenericMultipleTypes[T1 any, T2 any, T3 any](t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockGenericMultipleTypes[T1, T2, T3] {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockGenericMultipleTypes[T1, T2, T3]{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -102,10 +111,19 @@ func NewMockIndexListExpr(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockIndexListExpr {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockIndexListExpr{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/inpackage/subpkg/mocks_testify_inpackage_test.go
+++ b/internal/fixtures/inpackage/subpkg/mocks_testify_inpackage_test.go
@@ -18,10 +18,19 @@ func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockFoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/inpackage_import_collision/consumer/mocks_testify_dep_test.go
+++ b/internal/fixtures/inpackage_import_collision/consumer/mocks_testify_dep_test.go
@@ -17,10 +17,19 @@ func NewMockIface(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockIface {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockIface{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/interface_dir_relative/internal/fixtures/interface_dir_relative/mocks.go
+++ b/internal/fixtures/interface_dir_relative/internal/fixtures/interface_dir_relative/mocks.go
@@ -16,10 +16,19 @@ func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockFoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/interface_dir_relative/mocks/fixtures/interface_dir_relative/mocks.go
+++ b/internal/fixtures/interface_dir_relative/mocks/fixtures/interface_dir_relative/mocks.go
@@ -16,10 +16,19 @@ func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockFoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/method_args/same_name_arg_and_type/mocks_testify_same_name_arg_and_type_test.go
+++ b/internal/fixtures/method_args/same_name_arg_and_type/mocks_testify_same_name_arg_and_type_test.go
@@ -16,10 +16,19 @@ func newMockinterfaceA(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *mockinterfaceA {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &mockinterfaceA{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -202,10 +211,19 @@ func newMockinterfaceB(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *mockinterfaceB {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &mockinterfaceB{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -273,10 +291,19 @@ func newMockinterfaceB0(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *mockinterfaceB0 {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &mockinterfaceB0{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/mocks_io_test.go
+++ b/internal/fixtures/mocks_io_test.go
@@ -18,10 +18,19 @@ func NewMockReader(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockReader {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockReader{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -105,10 +114,19 @@ func NewMockWriter(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockWriter {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockWriter{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -192,10 +210,19 @@ func NewMockCloser(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockCloser {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockCloser{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -263,10 +290,19 @@ func NewMockSeeker(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockSeeker {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockSeeker{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -356,10 +392,19 @@ func NewMockReadWriter(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockReadWriter {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockReadWriter{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -503,10 +548,19 @@ func NewMockReadCloser(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockReadCloser {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockReadCloser{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -634,10 +688,19 @@ func NewMockWriteCloser(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockWriteCloser {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockWriteCloser{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -765,10 +828,19 @@ func NewMockReadWriteCloser(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockReadWriteCloser {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockReadWriteCloser{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -956,10 +1028,19 @@ func NewMockReadSeeker(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockReadSeeker {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockReadSeeker{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -1109,10 +1190,19 @@ func NewMockReadSeekCloser(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockReadSeekCloser {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockReadSeekCloser{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -1306,10 +1396,19 @@ func NewMockWriteSeeker(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockWriteSeeker {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockWriteSeeker{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -1459,10 +1558,19 @@ func NewMockReadWriteSeeker(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockReadWriteSeeker {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockReadWriteSeeker{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -1672,10 +1780,19 @@ func NewMockReaderFrom(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockReaderFrom {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockReaderFrom{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -1759,10 +1876,19 @@ func NewMockWriterTo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockWriterTo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockWriterTo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -1846,10 +1972,19 @@ func NewMockReaderAt(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockReaderAt {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockReaderAt{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -1939,10 +2074,19 @@ func NewMockWriterAt(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockWriterAt {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockWriterAt{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2032,10 +2176,19 @@ func NewMockByteReader(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockByteReader {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockByteReader{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2112,10 +2265,19 @@ func NewMockByteScanner(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockByteScanner {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockByteScanner{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2236,10 +2398,19 @@ func NewMockByteWriter(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockByteWriter {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockByteWriter{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2314,10 +2485,19 @@ func NewMockRuneReader(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRuneReader {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRuneReader{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2400,10 +2580,19 @@ func NewMockRuneScanner(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRuneScanner {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRuneScanner{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2530,10 +2719,19 @@ func NewMockStringWriter(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockStringWriter {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockStringWriter{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/mocks_matryer_test_test.go
+++ b/internal/fixtures/mocks_matryer_test_test.go
@@ -1842,6 +1842,82 @@ func (mock *MoqReplaceGenericSelf[T]) ResetCalls() {
 	mock.lockA.Unlock()
 }
 
+// Ensure that MoqConstructorTypeParams does implement ConstructorTypeParams.
+// If this is not the case, regenerate this file with mockery.
+var _ ConstructorTypeParams[any, any] = &MoqConstructorTypeParams[any, any]{}
+
+// MoqConstructorTypeParams is a mock implementation of ConstructorTypeParams.
+//
+//	func TestSomethingThatUsesConstructorTypeParams(t *testing.T) {
+//
+//		// make and configure a mocked ConstructorTypeParams
+//		mockedConstructorTypeParams := &MoqConstructorTypeParams{
+//			GetFunc: func() string {
+//				panic("mock out the Get method")
+//			},
+//		}
+//
+//		// use mockedConstructorTypeParams in code that requires ConstructorTypeParams
+//		// and then make assertions.
+//
+//	}
+type MoqConstructorTypeParams[Helper any, Ok any] struct {
+	// GetFunc mocks the Get method.
+	GetFunc func() string
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// Get holds details about calls to the Get method.
+		Get []struct {
+		}
+	}
+	lockGet sync.RWMutex
+}
+
+// Get calls GetFunc.
+func (mock *MoqConstructorTypeParams[helper, ok]) Get() string {
+	callInfo := struct {
+	}{}
+	mock.lockGet.Lock()
+	mock.calls.Get = append(mock.calls.Get, callInfo)
+	mock.lockGet.Unlock()
+	if mock.GetFunc == nil {
+		var (
+			s string
+		)
+		return s
+	}
+	return mock.GetFunc()
+}
+
+// GetCalls gets all the calls that were made to Get.
+// Check the length with:
+//
+//	len(mockedConstructorTypeParams.GetCalls())
+func (mock *MoqConstructorTypeParams[helper, ok]) GetCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGet.RLock()
+	calls = mock.calls.Get
+	mock.lockGet.RUnlock()
+	return calls
+}
+
+// ResetGetCalls reset all the calls that were made to Get.
+func (mock *MoqConstructorTypeParams[helper, ok]) ResetGetCalls() {
+	mock.lockGet.Lock()
+	mock.calls.Get = nil
+	mock.lockGet.Unlock()
+}
+
+// ResetCalls reset all the calls that were made to all mocked methods.
+func (mock *MoqConstructorTypeParams[helper, ok]) ResetCalls() {
+	mock.lockGet.Lock()
+	mock.calls.Get = nil
+	mock.lockGet.Unlock()
+}
+
 // Ensure that MoqHasConflictingNestedImports does implement HasConflictingNestedImports.
 // If this is not the case, regenerate this file with mockery.
 var _ HasConflictingNestedImports = &MoqHasConflictingNestedImports{}

--- a/internal/fixtures/mocks_net_http_test.go
+++ b/internal/fixtures/mocks_net_http_test.go
@@ -18,10 +18,19 @@ func NewMockResponseWriter(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockResponseWriter {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockResponseWriter{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/mocks_testify_test_test.go
+++ b/internal/fixtures/mocks_testify_test_test.go
@@ -25,10 +25,19 @@ func NewMockUsesAny(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockUsesAny {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockUsesAny{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -98,10 +107,19 @@ func NewMockFooer(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockFooer {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockFooer{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -269,10 +287,19 @@ func NewMockMapFunc(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockMapFunc {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockMapFunc{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -347,10 +374,19 @@ func NewMockAsyncProducer(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockAsyncProducer {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockAsyncProducer{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -512,10 +548,19 @@ func NewMockConsulLock(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockConsulLock {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockConsulLock{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -645,10 +690,19 @@ func NewMockKeyManager(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockKeyManager {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockKeyManager{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -742,10 +796,19 @@ func NewMockBlank(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockBlank {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockBlank{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -820,10 +883,19 @@ func NewMockExpecterAndRolledVariadic(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockExpecterAndRolledVariadic {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockExpecterAndRolledVariadic{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -1131,10 +1203,19 @@ func NewMockExpecter(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockExpecter {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockExpecter{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -1444,10 +1525,19 @@ func NewMockVariadicNoReturnInterface(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockVariadicNoReturnInterface {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockVariadicNoReturnInterface{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -1525,10 +1615,19 @@ func NewMockFuncArgsCollision(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockFuncArgsCollision {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockFuncArgsCollision{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -1606,10 +1705,19 @@ func NewMockRequesterGenerics[TAny any, TComparable comparable, TSigned constrai
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequesterGenerics[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequesterGenerics[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -1832,10 +1940,19 @@ func NewMockGetInt(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockGetInt {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockGetInt{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -1903,10 +2020,19 @@ func NewMockGetGeneric[T constraints.Integer](t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockGetGeneric[T] {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockGetGeneric[T]{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -1976,10 +2102,19 @@ func NewMockEmbeddedGet[T constraints.Signed](t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockEmbeddedGet[T] {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockEmbeddedGet[T]{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2049,10 +2184,19 @@ func NewMockReplaceGeneric[TImport any, TConstraint constraints.Signed, TKeep an
 	mock.TestingT
 	Cleanup(func())
 }) *MockReplaceGeneric[TImport, TConstraint, TKeep] {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockReplaceGeneric[TImport, TConstraint, TKeep]{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2221,10 +2365,19 @@ func NewMockReplaceGenericSelf[T any](t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockReplaceGenericSelf[T] {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockReplaceGenericSelf[T]{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2288,16 +2441,105 @@ func (_c *MockReplaceGenericSelf_A_Call[T]) RunAndReturn(run func() T) *MockRepl
 	return _c
 }
 
+// NewMockConstructorTypeParams creates a new instance of MockConstructorTypeParams. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewMockConstructorTypeParams[helper any, ok any](t interface {
+	mock.TestingT
+	Cleanup(func())
+}) *MockConstructorTypeParams[helper, ok] {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
+	mock := &MockConstructorTypeParams[helper, ok]{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
+
+	return mock
+}
+
+// MockConstructorTypeParams is an autogenerated mock type for the ConstructorTypeParams type
+type MockConstructorTypeParams[helper any, ok any] struct {
+	mock.Mock
+}
+
+type MockConstructorTypeParams_Expecter[helper any, ok any] struct {
+	mock *mock.Mock
+}
+
+func (_m *MockConstructorTypeParams[helper, ok]) EXPECT() *MockConstructorTypeParams_Expecter[helper, ok] {
+	return &MockConstructorTypeParams_Expecter[helper, ok]{mock: &_m.Mock}
+}
+
+// Get provides a mock function for the type MockConstructorTypeParams
+func (_mock *MockConstructorTypeParams[helper, ok]) Get() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Get")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// MockConstructorTypeParams_Get_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Get'
+type MockConstructorTypeParams_Get_Call[helper any, ok any] struct {
+	*mock.Call
+}
+
+// Get is a helper method to define mock.On call
+func (_e *MockConstructorTypeParams_Expecter[helper, ok]) Get() *MockConstructorTypeParams_Get_Call[helper, ok] {
+	return &MockConstructorTypeParams_Get_Call[helper, ok]{Call: _e.mock.On("Get")}
+}
+
+func (_c *MockConstructorTypeParams_Get_Call[helper, ok]) Run(run func()) *MockConstructorTypeParams_Get_Call[helper, ok] {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockConstructorTypeParams_Get_Call[helper, ok]) Return(s string) *MockConstructorTypeParams_Get_Call[helper, ok] {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *MockConstructorTypeParams_Get_Call[helper, ok]) RunAndReturn(run func() string) *MockConstructorTypeParams_Get_Call[helper, ok] {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockHasConflictingNestedImports creates a new instance of MockHasConflictingNestedImports. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockHasConflictingNestedImports(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockHasConflictingNestedImports {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockHasConflictingNestedImports{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2425,10 +2667,19 @@ func NewMockImportsSameAsPackage(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockImportsSameAsPackage {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockImportsSameAsPackage{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2582,10 +2833,19 @@ func NewMockGenericInterface[M any](t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockGenericInterface[M] {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockGenericInterface[M]{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2660,10 +2920,19 @@ func NewMockInstantiatedGenericInterface(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockInstantiatedGenericInterface {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockInstantiatedGenericInterface{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2738,10 +3007,19 @@ func NewMockMyReader(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockMyReader {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockMyReader{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2825,10 +3103,19 @@ func NewMockIssue766(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockIssue766 {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockIssue766{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2914,10 +3201,19 @@ func NewMockMapToInterface(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockMapToInterface {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockMapToInterface{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -2989,10 +3285,19 @@ func NewMockSibling(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockSibling {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockSibling{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -3049,10 +3354,19 @@ func NewMockUsesOtherPkgIface(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockUsesOtherPkgIface {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockUsesOtherPkgIface{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -3116,10 +3430,19 @@ func NewMockNilRun(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockNilRun {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockNilRun{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -3183,10 +3506,19 @@ func NewMockPanicOnNoReturnValue(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockPanicOnNoReturnValue {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockPanicOnNoReturnValue{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -3254,10 +3586,19 @@ func NewMockRequester(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequester {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequester{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -3341,10 +3682,19 @@ func NewMockRequester2(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequester2 {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequester2{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -3419,10 +3769,19 @@ func NewMockRequester3(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequester3 {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequester3{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -3490,10 +3849,19 @@ func NewMockRequester4(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequester4 {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequester4{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -3550,10 +3918,19 @@ func NewMockRequesterArgSameAsImport(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequesterArgSameAsImport {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequesterArgSameAsImport{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -3630,10 +4007,19 @@ func NewMockRequesterArgSameAsNamedImport(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequesterArgSameAsNamedImport {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequesterArgSameAsNamedImport{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -3710,10 +4096,19 @@ func NewMockRequesterArgSameAsPkg(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequesterArgSameAsPkg {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequesterArgSameAsPkg{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -3777,10 +4172,19 @@ func NewMockRequesterArray(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequesterArray {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequesterArray{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -3866,10 +4270,19 @@ func NewMockRequesterElided(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequesterElided {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequesterElided{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -3950,10 +4363,19 @@ func NewMockRequesterIface(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequesterIface {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequesterIface{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -4023,10 +4445,19 @@ func NewMockRequesterNS(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequesterNS {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequesterNS{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -4110,10 +4541,19 @@ func NewMockRequesterPtr(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequesterPtr {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequesterPtr{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -4199,10 +4639,19 @@ func NewMockRequesterReturnElided(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequesterReturnElided {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequesterReturnElided{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -4358,10 +4807,19 @@ func NewMockRequesterSlice(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequesterSlice {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequesterSlice{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -4447,10 +4905,19 @@ func newMockrequesterUnexported(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *mockrequesterUnexported {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &mockrequesterUnexported{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -4507,10 +4974,19 @@ func NewMockRequesterVariadicOneArgument(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequesterVariadicOneArgument {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequesterVariadicOneArgument{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -4786,10 +5262,19 @@ func NewMockRequesterVariadic(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockRequesterVariadic {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockRequesterVariadic{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -5069,10 +5554,19 @@ func NewMockExample(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockExample {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockExample{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -5244,10 +5738,19 @@ func NewMockA(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockA {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockA{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -5324,10 +5827,19 @@ func NewMockStructWithTag(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockStructWithTag {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockStructWithTag{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -5440,10 +5952,19 @@ func NewMockUnsafeInterface(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockUnsafeInterface {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockUnsafeInterface{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -5507,10 +6028,19 @@ func NewMockVariadic(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockVariadic {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockVariadic{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -5591,10 +6121,19 @@ func NewMockVariadicReturnFunc(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockVariadicReturnFunc {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockVariadicReturnFunc{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -5671,10 +6210,19 @@ func NewMockVariadicWithMultipleReturnsUnrollVariadic(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockVariadicWithMultipleReturnsUnrollVariadic {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockVariadicWithMultipleReturnsUnrollVariadic{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -5777,10 +6325,19 @@ func NewMockVariadicWithMultipleReturns(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockVariadicWithMultipleReturns {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockVariadicWithMultipleReturns{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -5879,10 +6436,19 @@ func NewMockVariadicWithNoReturns(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockVariadicWithNoReturns {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockVariadicWithNoReturns{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/multi_template/mocks_testify_multitemplate_test.go
+++ b/internal/fixtures/multi_template/mocks_testify_multitemplate_test.go
@@ -16,10 +16,19 @@ func NewMockTestifyFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockTestifyFoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockTestifyFoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/recursive_generation/mocks_testify_recursive_generation_test.go
+++ b/internal/fixtures/recursive_generation/mocks_testify_recursive_generation_test.go
@@ -16,10 +16,19 @@ func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockFoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/recursive_generation/subpkg1/mocks_testify_subpkg1_test.go
+++ b/internal/fixtures/recursive_generation/subpkg1/mocks_testify_subpkg1_test.go
@@ -16,10 +16,19 @@ func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockFoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/recursive_generation/subpkg2/mocks_testify_subpkg2_test.go
+++ b/internal/fixtures/recursive_generation/subpkg2/mocks_testify_subpkg2_test.go
@@ -16,10 +16,19 @@ func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockFoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/recursive_generation_with_subpkg_exclude/mocks.go
+++ b/internal/fixtures/recursive_generation_with_subpkg_exclude/mocks.go
@@ -16,10 +16,19 @@ func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockFoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/recursive_generation_with_subpkg_exclude/subpkg1/mocks.go
+++ b/internal/fixtures/recursive_generation_with_subpkg_exclude/subpkg1/mocks.go
@@ -16,10 +16,19 @@ func NewMockFoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockFoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockFoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/replace_type_pointers/mocks_testify_replace_type_pointers_test.go
+++ b/internal/fixtures/replace_type_pointers/mocks_testify_replace_type_pointers_test.go
@@ -16,10 +16,19 @@ func NewMockInterfaceWithPointers(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockInterfaceWithPointers {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockInterfaceWithPointers{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/type_alias/mocks_testify_type_alias_test.go
+++ b/internal/fixtures/type_alias/mocks_testify_type_alias_test.go
@@ -17,10 +17,19 @@ func NewMockAliasToInterface3(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockAliasToInterface3 {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockAliasToInterface3{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -88,10 +97,19 @@ func NewMockInterface1(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockInterface1 {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockInterface1{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -159,10 +177,19 @@ func NewMockInterface2(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockInterface2 {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockInterface2{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/fixtures/unexported/mocks_testify_unexported_test.go
+++ b/internal/fixtures/unexported/mocks_testify_unexported_test.go
@@ -16,10 +16,19 @@ func newMockfoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *mockfoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &mockfoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/mock_testify.templ
+++ b/internal/mock_testify.templ
@@ -34,10 +34,19 @@ func {{ $constructorName }}{{ $mock.TypeConstraint }} (t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *{{ .StructName }}{{ $mock.TypeInstantiation }} {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &{{ .StructName }}{{ $mock.TypeInstantiation }}{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/mocks_testify_main_test.go
+++ b/mocks_testify_main_test.go
@@ -16,10 +16,19 @@ func newMockfoo(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *mockfoo {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &mockfoo{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }


### PR DESCRIPTION
## Description

When generated testify mocks have unmet expectations, cleanup failures point into the generated mock instead of the test that constructed it. Mark the constructor and its cleanup callback as helpers when the supplied testing object supports `Helper()`, preserving compatibility with existing `TestingT` implementations that do not.

Keep the helper assertions in nested scopes so generic type parameters named `helper` or `ok` remain valid. Add regression coverage for the actual reported caller line, testing objects without `Helper`, and generic constructors. The bulk of the diff updates checked-in generated fixtures.

Fixes #1143.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Version of Go used when building/testing

Go 1.26.0 on macOS arm64.

## How Has This Been Tested?

- `go run github.com/go-task/task/v3/cmd/task test test.e2e`: 175 unit tests, all shell e2e scenarios, and 5 Go e2e tests passed.
- `go run github.com/go-task/task/v3/cmd/task lint`: 0 issues.
- Repeated `mocks.generate` produced an identical patch; hand-written changes pass `gofumpt` and `git diff --check`.
- The caller-location regression failed against the original generated mocks and passes after regeneration.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

No documentation changes are needed for this correction to test failure locations.
