### PR TITLE
fix(matryer): honor interface-level skip-ensure imports

### DIFF
--- a/e2e/test_matryer_skip_ensure/skip_ensure_test.go
+++ b/e2e/test_matryer_skip_ensure/skip_ensure_test.go
@@ -1,0 +1,87 @@
+package test_matryer_skip_ensure
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterfaceSkipEnsure(t *testing.T) {
+	binary := filepath.Join(t.TempDir(), "mockery")
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
+	}
+	build := exec.CommandContext(t.Context(), "go", "build", "-o", binary, "github.com/vektra/mockery/v3")
+	build.Env = append(os.Environ(), "GOWORK=off")
+	output, err := build.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	for _, tt := range []struct {
+		name         string
+		fileSkip     bool
+		firstSkip    bool
+		secondSkip   bool
+		mixed        bool
+		methodImport bool
+	}{
+		{name: "interface disables ensure", firstSkip: true},
+		{name: "interface enables ensure", fileSkip: true},
+		{name: "mixed shared output", fileSkip: true, mixed: true, secondSkip: true},
+		{name: "method retains source import", firstSkip: true, methodImport: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.Mkdir(filepath.Join(dir, "api"), 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/skipensure\n\ngo 1.25.5\n"), 0o600))
+			source := "package api\ntype First interface { Ping() string }; type Second interface { Pong() string }; type Value struct { N int }; type Typed interface { Get() Value }\n"
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "api", "api.go"), []byte(source), 0o600))
+			first := "First"
+			if tt.methodImport {
+				first = "Typed"
+			}
+			interfaces := map[string]any{
+				first: map[string]any{"config": map[string]any{"template-data": map[string]any{"skip-ensure": tt.firstSkip}}},
+			}
+			if tt.mixed {
+				interfaces["Second"] = map[string]any{"config": map[string]any{"template-data": map[string]any{"skip-ensure": tt.secondSkip}}}
+			}
+			config := map[string]any{
+				"template": "matryer", "all": false, "force-file-write": true,
+				"dir": "./mocks", "filename": "mocks.go", "pkgname": "mocks", "structname": "{{.InterfaceName}}Mock",
+				"template-data": map[string]any{"skip-ensure": tt.fileSkip},
+				"packages":      map[string]any{"example.com/skipensure/api": map[string]any{"interfaces": interfaces}},
+			}
+			data, err := json.Marshal(config)
+			require.NoError(t, err)
+			configPath := filepath.Join(dir, "mockery.yml")
+			require.NoError(t, os.WriteFile(configPath, data, 0o600))
+			generate := exec.CommandContext(t.Context(), binary, "--config", configPath)
+			generate.Dir = dir
+			generate.Env = append(os.Environ(), "GOWORK=off")
+			output, err := generate.CombinedOutput()
+			require.NoError(t, err, string(output))
+
+			consumer := "package mocks\nimport \"testing\"\n"
+			if tt.methodImport {
+				consumer += "import \"example.com/skipensure/api\"\nfunc TestGenerated(t *testing.T) { m := &TypedMock{GetFunc:func() api.Value {return api.Value{N:7}}}; if m.Get().N!=7 || len(m.GetCalls())!=1 {t.Fatal(\"mock behavior\")} }\n"
+			} else {
+				consumer += "func TestGenerated(t *testing.T) { m := &FirstMock{PingFunc:func()string{return \"ok\"}}; if m.Ping()!=\"ok\" || len(m.PingCalls())!=1 {t.Fatal(\"mock behavior\")}"
+				if tt.mixed {
+					consumer += "; second := &SecondMock{PongFunc:func()string{return \"pong\"}}; if second.Pong()!=\"pong\" || len(second.PongCalls())!=1 {t.Fatal(\"second mock behavior\")}"
+				}
+				consumer += "}\n"
+			}
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "mocks", "consumer_test.go"), []byte(consumer), 0o600))
+			test := exec.CommandContext(t.Context(), "go", "test", "-count=1", "./...")
+			test.Dir = dir
+			test.Env = append(os.Environ(), "GOWORK=off")
+			output, err = test.CombinedOutput()
+			require.NoError(t, err, string(output))
+		})
+	}
+}

--- a/internal/matryer_imports_test.go
+++ b/internal/matryer_imports_test.go
@@ -1,0 +1,112 @@
+package internal
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vektra/mockery/v3/template"
+	"golang.org/x/tools/go/packages"
+)
+
+type matryerSourceImporter struct {
+	pkg *types.Package
+}
+
+func (i matryerSourceImporter) Import(path string) (*types.Package, error) {
+	if path == i.pkg.Path() {
+		return i.pkg, nil
+	}
+	return nil, fmt.Errorf("unexpected import %q", path)
+}
+
+func TestMatryerEnsureImports(t *testing.T) {
+	const sourcePath = "example.com/source"
+	const source = "package source; type First interface{}; type Second interface{}; type Value struct{}"
+
+	for _, tt := range []struct {
+		name          string
+		fileSkip      bool
+		interfaceSkip []bool
+		inPackage     bool
+		keepImport    bool
+		explicitAlias bool
+		wantImports   int
+	}{
+		{name: "default ensure", interfaceSkip: []bool{false}, wantImports: 1},
+		{name: "interface skips ensure", interfaceSkip: []bool{true}},
+		{name: "all interfaces skip ensure", interfaceSkip: []bool{true, true}},
+		{name: "interface overrides file skip", fileSkip: true, interfaceSkip: []bool{false}, wantImports: 1},
+		{name: "mixed interfaces", interfaceSkip: []bool{true, false}, wantImports: 1},
+		{name: "mixed interfaces override file skip", fileSkip: true, interfaceSkip: []bool{false, true}, wantImports: 1},
+		{name: "file and interfaces skip", fileSkip: true, interfaceSkip: []bool{true, true}},
+		{name: "existing type import remains", interfaceSkip: []bool{true}, keepImport: true, wantImports: 1},
+		{name: "later interface supplies source alias", interfaceSkip: []bool{false, false}, explicitAlias: true, wantImports: 1},
+		{name: "skipped sibling supplies source alias", fileSkip: true, interfaceSkip: []bool{false, true}, explicitAlias: true, wantImports: 1},
+		{name: "same package skips", interfaceSkip: []bool{true}, inPackage: true},
+		{name: "same package ensures", fileSkip: true, interfaceSkip: []bool{false}, inPackage: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			sourceFile, err := parser.ParseFile(fset, "source.go", source, parser.SkipObjectResolution)
+			require.NoError(t, err)
+			sourceConfig := types.Config{}
+			sourcePkg, err := sourceConfig.Check(sourcePath, fset, []*ast.File{sourceFile}, nil)
+			require.NoError(t, err)
+
+			pkgName, pkgPath, qualifier := "mocks", "example.com/mocks", "source."
+			if tt.inPackage {
+				pkgName, pkgPath, qualifier = "source", sourcePath, ""
+			}
+			registry, err := template.NewRegistry(&packages.Package{Name: "source", PkgPath: sourcePath, Types: sourcePkg}, pkgPath, tt.inPackage)
+			require.NoError(t, err)
+			if tt.keepImport {
+				registry.AddImport("source", sourcePath)
+			}
+			interfaces := make(template.Interfaces, len(tt.interfaceSkip))
+			for i, skip := range tt.interfaceSkip {
+				name := []string{"First", "Second"}[i]
+				interfaces[i] = template.Interface{
+					Name: name, StructName: name + "Mock", TemplateData: template.TemplateData{"skip-ensure": skip},
+				}
+			}
+			if tt.keepImport {
+				interfaces[0].TemplateData["struct-preamble"] = "Value source.Value"
+			}
+			wantQualifier := qualifier
+			if tt.explicitAlias {
+				interfaces[1].TemplateData["add-import"] = []any{map[string]any{"name": "src", "pkgPath": sourcePath}}
+				wantQualifier = "src."
+			}
+			data := template.Data{
+				PkgName: pkgName, SrcPkgQualifier: qualifier, Registry: registry,
+				TemplateData: template.TemplateData{"skip-ensure": tt.fileSkip}, Interfaces: interfaces,
+			}
+			tmpl, err := template.New(templateMatryer, "matryer")
+			require.NoError(t, err)
+			var output bytes.Buffer
+			require.NoError(t, tmpl.Execute(&output, data))
+
+			generated, err := parser.ParseFile(fset, "mocks.go", output.Bytes(), parser.SkipObjectResolution)
+			require.NoError(t, err)
+			files := []*ast.File{generated}
+			if tt.inPackage {
+				files = append(files, sourceFile)
+			}
+			checker := types.Config{Importer: matryerSourceImporter{pkg: sourcePkg}}
+			_, err = checker.Check(pkgPath, fset, files, nil)
+			require.NoError(t, err, output.String())
+			require.Len(t, registry.Imports(), tt.wantImports)
+			for i, skip := range tt.interfaceSkip {
+				assertion := "var _ " + wantQualifier + interfaces[i].Name
+				require.Equal(t, !skip, strings.Contains(output.String(), assertion), output.String())
+			}
+		})
+	}
+}

--- a/internal/mock_matryer.templ
+++ b/internal/mock_matryer.templ
@@ -23,8 +23,10 @@ package {{.PkgName}}
 {{- end }}
 
 {{$srcPkgQualifier := $.SrcPkgQualifier}}
-{{- if not (index .TemplateData "skip-ensure") }}
-	{{- $_ := $.Registry.AddImport $.Registry.SrcPkgName $.Registry.SrcPkg.PkgPath }}
+{{- range .Interfaces }}
+	{{- if not (index .TemplateData "skip-ensure") }}
+		{{- $_ := $.Registry.AddImport $.Registry.SrcPkgName $.Registry.SrcPkg.PkgPath }}
+	{{- end }}
 {{- end }}
 
 import (


### PR DESCRIPTION
Description
-------------

Fixes #1082.

Register the Matryer source-package import when at least one interface actually emits an ensure declaration. The import section previously checked file-level `TemplateData`, while the declarations check each interface's effective `TemplateData`.

That mismatch can produce either an unused source import (an interface opts out) or an undefined package qualifier (the file opts out and an interface opts back in).

This changes only the ensure-related registration. Configuration inheritance is unchanged; method-type imports remain intact, and explicit `add-import` entries are still processed before automatic ensure imports so a later interface can supply the source alias.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Version of Go used when building/testing:
---------------------------------------------

- [x] 1.26.8
- [x] 1.27.1

How Has This Been Tested?
---------------------------

- Twelve template/registry regression cases, including both override directions, mixed interfaces, same-package generation, existing type imports, and aliases supplied by later interfaces. Generated code is parsed and checked with `go/types`, not just formatted.
- Four end-to-end cases build and invoke the real CLI, compile the generated mocks in separate modules, and call the generated methods/check call histories. Three fail on the original implementation; all four pass with the fix. Four of the twelve template cases also fail before the fix.
- Eleven additional real CLI/consumer scenarios reproduce six original compiler failures; all eleven compile and run after the change. The five previously working controls retain byte-identical generated code.
- The repository's complete `test.ci` flow passes on Go 1.26.8 and 1.27.1: lint, complete mock regeneration, `git-state`, 217 unit-test events, shell generation checks, and 10 end-to-end test events. The Go 1.26 run was repeated with `--force` so Task did not reuse lint/tool-building cache decisions.
- `GOFLAGS='-mod=readonly -race' GOWORK=off go test -count=1 -json ./...` passes with 229 test events and no failures; the flag is inherited by the CLI/consumer subprocesses too.

Reproduce the focused tests:

```sh
GOWORK=off go test ./internal ./e2e/test_matryer_skip_ensure \
  -run '^(TestMatryerEnsureImports|TestInterfaceSkipEnsure)$' -count=1 -v
```

No generated fixtures, dependency manifests, or template-data merge rules are changed.

Checklist
-----------

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

No documentation change is needed: the existing interface-level option now generates compilable code consistently.
